### PR TITLE
fix: terraform glitches

### DIFF
--- a/rotterdam.tf
+++ b/rotterdam.tf
@@ -96,7 +96,7 @@ resource "github_repository_collaborators" "rotterdam" {
   }
 
   team {
-    permission = "maintain"
+    permission = "push"
     team_id    = github_team.frameless.slug
   }
 

--- a/utrecht.tf
+++ b/utrecht.tf
@@ -103,7 +103,7 @@ resource "github_repository_collaborators" "utrecht" {
   }
 
   team {
-    permission = "maintain"
+    permission = "push"
     team_id    = github_team.frameless.slug
   }
 


### PR DESCRIPTION
Een PR die hopelijk de (meeste) terraform "glitches" fixt. Daarmee bedoel ik: de settings telkens opnieuw gedaan worden als je terraform apply doet, zonder dat je iets aan de config aanpast.

Hopelijk vinden we later nog een oplossing om `squash_merge_commit_*` settings alsnog goed in te stellen.