### PR TITLE
fix: branch protection name for index repo

### DIFF
--- a/index.tf
+++ b/index.tf
@@ -45,7 +45,7 @@ resource "github_branch_protection" "index-main" {
 
   required_status_checks {
     strict   = false
-    contexts = ["continuous-integration"]
+    contexts = ["Continuous integration"]
   }
 
   required_pull_request_reviews {


### PR DESCRIPTION
Allows this PR to be automerged:
https://github.com/nl-design-system/index/pull/367