### PR TITLE
chore: add `maintainer` nested team for Logius

### DIFF
--- a/lux.tf
+++ b/lux.tf
@@ -104,11 +104,6 @@ resource "github_repository_collaborators" "lux" {
   }
 
   team {
-    permission = "maintain"
-    team_id    = github_team.logius-maintainer.slug
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.logius-committer.slug
   }

--- a/team-members.tf
+++ b/team-members.tf
@@ -113,3 +113,11 @@ resource "github_team_members" "logius-committer" {
     username = data.github_user.remy-parzinski.username
   }
 }
+
+resource "github_team_members" "logius-maintainer" {
+  team_id = github_team.logius-maintainer.id
+
+  members {
+    username = data.github_user.aline-nap.username
+  }
+}

--- a/team.tf
+++ b/team.tf
@@ -134,15 +134,15 @@ resource "github_team" "logius" {
   privacy     = "closed"
 }
 
-resource "github_team" "logius-maintainer" {
-  name           = "logius-maintainer"
+resource "github_team" "logius-committer" {
+  name           = "logius-committer"
   parent_team_id = github_team.logius.id
   privacy        = "closed"
 }
 
-resource "github_team" "logius-committer" {
-  name           = "logius-committer"
-  parent_team_id = github_team.logius.id
+resource "github_team" "logius-maintainer" {
+  name           = "logius-maintainer"
+  parent_team_id = github_team.logius-committer.id
   privacy        = "closed"
 }
 


### PR DESCRIPTION
GitHub suggereert dat we nested teams moeten gebruiken voor meer privileges: [About teams: Preparing to nest teams in your organization](https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams#preparing-to-nest-teams-in-your-organization):

> At the top of the team hierarchy, you should give parent teams repository access permissions that are safe for every member of the parent team and its child teams. As you move toward the bottom of the hierarchy, you can grant child teams additional, more granular access to more sensitive repositories.

Misschien lost dit ook het probleem op van de notifications die we steeds krijgen door "conflicting roles".

Dus nu is het idee:

- `committer`: push rechten
  - `maintainer` 1 of meer committers zijn ook maintainer