### PR TITLE
refactor: use nested teems to avoid conflicting roles

### DIFF
--- a/team-members.tf
+++ b/team-members.tf
@@ -52,7 +52,6 @@ resource "github_team_members" "kernteam-committer" {
     username = data.github_user.rianrietveld.username
   }
 
-
   members {
     username = data.github_user.rozerin.username
   }
@@ -119,6 +118,14 @@ resource "github_team_members" "kernteam-triage" {
 
   members {
     username = data.github_user.astrid-01.username
+  }
+
+  members {
+    username = data.github_user.rozerin.username
+  }
+
+  members {
+    username = data.github_user.wartburggraaf.username
   }
 }
 

--- a/team-members.tf
+++ b/team-members.tf
@@ -62,6 +62,25 @@ resource "github_team_members" "kernteam-committer" {
   }
 }
 
+resource "github_team_members" "kernteam-maintainer" {
+  team_id = github_team.kernteam-committer.id
+
+  members {
+    username = data.github_user.robbert.username
+  }
+
+  members {
+    username = data.github_user.hidde.username
+  }
+
+  members {
+    username = data.github_user.matijs.username
+  }
+
+  members {
+    username = data.github_user.yolijn.username
+  }
+}
 
 resource "github_team_members" "kernteam-triage" {
   team_id = github_team.kernteam-triage.id

--- a/team.tf
+++ b/team.tf
@@ -20,7 +20,7 @@ resource "github_team" "kernteam-admin" {
 
 resource "github_team" "kernteam-committer" {
   name           = "kernteam-committer"
-  parent_team_id = github_team.kernteam.id
+  parent_team_id = github_team.kernteam-triage.id
   privacy        = "closed"
 }
 
@@ -39,7 +39,7 @@ resource "github_team" "kernteam-developers" {
 
 resource "github_team" "kernteam-maintainer" {
   name           = "kernteam-maintainer"
-  parent_team_id = github_team.kernteam.id
+  parent_team_id = github_team.kernteam-committer.id
   privacy        = "closed"
 }
 


### PR DESCRIPTION
- `kernteam`: iedereen
  - `kernteam-triage`: rechten voor issues maken enzo
    - `kernteam-committer`: rechten voor commits doen voor pull requests alle nl-design-system repositories
      - `kernteam-maintainer`: rechten voor repositories beheren