### PR TITLE
feat: add RVO maintainer team ahead of RVO repo config

### DIFF
--- a/team-members.tf
+++ b/team-members.tf
@@ -166,3 +166,27 @@ resource "github_team_members" "tilburg-acato-maintainer" {
     username = data.github_user.acato-jorik-bosman.username
   }
 }
+
+resource "github_team_members" "rvo" {
+  team_id = github_team.rvo.id
+
+  members {
+    username = data.github_user.robert-roose.username
+  }
+}
+
+resource "github_team_members" "rvo-committer" {
+  team_id = github_team.rvo-committer.id
+
+  members {
+    username = data.github_user.robert-roose.username
+  }
+}
+
+resource "github_team_members" "rvo-maintainer" {
+  team_id = github_team.rvo-maintainer.id
+
+  members {
+    username = data.github_user.robert-roose.username
+  }
+}

--- a/team.tf
+++ b/team.tf
@@ -128,6 +128,18 @@ resource "github_team" "rvo" {
   privacy     = "closed"
 }
 
+resource "github_team" "rvo-committer" {
+  name           = "rvo-committer"
+  parent_team_id = github_team.rvo.id
+  privacy        = "closed"
+}
+
+resource "github_team" "rvo-maintainer" {
+  name           = "rvo-maintainer"
+  parent_team_id = github_team.rvo-committer.id
+  privacy        = "closed"
+}
+
 resource "github_team" "logius" {
   name        = "logius"
   description = "Logius"

--- a/terraform.tf
+++ b/terraform.tf
@@ -76,6 +76,11 @@ resource "github_repository_collaborators" "terraform" {
 
   team {
     permission = "push"
+    team_id    = github_team.rvo-maintainer.slug
+  }
+
+  team {
+    permission = "push"
     team_id    = github_team.tilburg-acato-maintainer.slug
   }
 

--- a/user.tf
+++ b/user.tf
@@ -93,3 +93,7 @@ data "github_user" "acato-mark" {
 data "github_user" "acato-cguijt" {
   username = "cguijt"
 }
+
+data "github_user" "robert-roose" {
+  username = "rroose-rvo"
+}


### PR DESCRIPTION
Having the maintainer available first allows us to let the maintainer review the first batch of team members.