### PR TITLE
fix: username casing

### DIFF
--- a/team-members.tf
+++ b/team-members.tf
@@ -6,10 +6,12 @@ resource "github_team_members" "frameless-maintainer" {
 
   # members {
   #   username = data.github_user.yolijn.username
+  #   role     = "maintainer"
   # }
 
   # members {
   #   username = data.github_user.robbert.username
+  #   role     = "maintainer"
   # }
 
   members {
@@ -22,6 +24,8 @@ resource "github_team_members" "kernteam-committer" {
 
   members {
     username = data.github_user.robbert.username
+    # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
+    role     = "maintainer"
   }
 
   members {
@@ -46,6 +50,8 @@ resource "github_team_members" "kernteam-committer" {
 
   members {
     username = data.github_user.yolijn.username
+    # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
+    role     = "maintainer"
   }
 
   members {
@@ -66,6 +72,8 @@ resource "github_team_members" "kernteam-maintainer" {
 
   members {
     username = data.github_user.robbert.username
+    # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
+    role     = "maintainer"
   }
 
   members {
@@ -78,6 +86,8 @@ resource "github_team_members" "kernteam-maintainer" {
 
   members {
     username = data.github_user.yolijn.username
+    # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
+    role     = "maintainer"
   }
 }
 
@@ -86,6 +96,8 @@ resource "github_team_members" "kernteam-triage" {
 
   members {
     username = data.github_user.robbert.username
+    # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
+    role     = "maintainer"
   }
 
   members {
@@ -102,6 +114,8 @@ resource "github_team_members" "kernteam-triage" {
 
   members {
     username = data.github_user.yolijn.username
+    # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
+    role     = "maintainer"
   }
 
   members {

--- a/user.tf
+++ b/user.tf
@@ -11,7 +11,7 @@ data "github_user" "astrid-01" {
 }
 
 data "github_user" "hidde" {
-  username = "Hidde"
+  username = "hidde"
 }
 
 data "github_user" "jeffreylauwers" {


### PR DESCRIPTION
Make owners maintainers instead of members to prevent:

> Attempting to set a user who is an organization owner to "member" will
result in the user being granted "maintainer" instead; this can result in a perpetual `terraform plan` diff that changes their status back to "member".