### PR TITLE
build: switch to Terraform Cloud app on GitHub

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,43 +1,20 @@
-name: Terraform Apply
-on:
-  push:
-    branches:
-      - main
-
-env:
-  TF_CLOUD_ORGANIZATION: '${{ secrets.TF_CLOUD_ORGANIZATION }}'
-  TF_API_TOKEN: '${{ secrets.TF_API_TOKEN }}'
-  TF_WORKSPACE: '${{ secrets.TF_WORKSPACE }}'
-  CONFIG_DIRECTORY: './'
+name: Terraform
+on: pull_request
 
 jobs:
   terraform:
-    name: Terraform Apply
+    name: Terraform format check
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-      - name: Upload Configuration
-        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.0.0
-        id: apply-upload
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
-          workspace: ${{ env.TF_WORKSPACE }}
-          directory: ${{ env.CONFIG_DIRECTORY }}
+          terraform_version: "~> 1.7.3"
+          terraform_wrapper: false
 
-      - name: Create Apply Run
-        uses: hashicorp/tfc-workflows-github/actions/create-run@v1.0.0
-        id: apply-run
-        with:
-          workspace: ${{ env.TF_WORKSPACE }}
-          configuration_version: ${{ steps.apply-upload.outputs.configuration_version_id }}
+      - name: Check Terraform files
+        run: terraform fmt -check
 
-      - name: Apply
-        uses: hashicorp/tfc-workflows-github/actions/apply-run@v1.0.0
-        if: fromJSON(steps.apply-run.outputs.payload).data.attributes.actions.IsConfirmable
-        id: apply
-        with:
-          run: ${{ steps.apply-run.outputs.run_id }}
-          comment: 'Apply Run from GitHub Actions CI ${{ github.sha }}'

--- a/team-members.tf
+++ b/team-members.tf
@@ -25,7 +25,7 @@ resource "github_team_members" "kernteam-committer" {
   members {
     username = data.github_user.robbert.username
     # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
-    role     = "maintainer"
+    role = "maintainer"
   }
 
   members {
@@ -51,7 +51,7 @@ resource "github_team_members" "kernteam-committer" {
   members {
     username = data.github_user.yolijn.username
     # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
-    role     = "maintainer"
+    role = "maintainer"
   }
 
   members {
@@ -73,7 +73,7 @@ resource "github_team_members" "kernteam-maintainer" {
   members {
     username = data.github_user.robbert.username
     # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
-    role     = "maintainer"
+    role = "maintainer"
   }
 
   members {
@@ -87,7 +87,7 @@ resource "github_team_members" "kernteam-maintainer" {
   members {
     username = data.github_user.yolijn.username
     # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
-    role     = "maintainer"
+    role = "maintainer"
   }
 }
 
@@ -97,7 +97,7 @@ resource "github_team_members" "kernteam-triage" {
   members {
     username = data.github_user.robbert.username
     # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
-    role     = "maintainer"
+    role = "maintainer"
   }
 
   members {
@@ -115,7 +115,7 @@ resource "github_team_members" "kernteam-triage" {
   members {
     username = data.github_user.yolijn.username
     # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
-    role     = "maintainer"
+    role = "maintainer"
   }
 
   members {
@@ -149,7 +149,7 @@ resource "github_team_members" "kernteam-dependabot" {
   members {
     username = data.github_user.robbert.username
     # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
-    role     = "maintainer"
+    role = "maintainer"
   }
 
   members {

--- a/terraform.tf
+++ b/terraform.tf
@@ -44,7 +44,8 @@ resource "github_branch_protection" "terraform-main" {
 
   required_status_checks {
     # Require branches to be up to date before merging
-    strict = true
+    strict   = true
+    contexts = ["Terraform Cloud/nI-design-system/repo-id-1TeEm4rfMfsg6Y6G", "Terraform format check"]
   }
 
   required_pull_request_reviews {


### PR DESCRIPTION
Switch the current setup of using GitHub Actions for Terraform "plan" and "apply" runs to using the official Terraform Cloud app for GitHub.

Replace the old starter action with a "Terraform format check" that only checks if `terraform fmt` was run locally.

In a subsequent pull request the "Terraform format check" check will be added to the "terraform-main" `github_branch_protection`.