### PR TITLE
fix: duplicate team name

### DIFF
--- a/team.tf
+++ b/team.tf
@@ -349,7 +349,7 @@ resource "github_team" "vng-services" {
 }
 
 resource "github_team" "vng-services-committer" {
-  name           = "vng-services"
+  name           = "vng-services-committer"
   parent_team_id = github_team.vng-services.id
   privacy        = "closed"
 }


### PR DESCRIPTION
Fixes:

```txt
│ Error: POST https://api.github.com/orgs/nl-design-system/teams: 422 Validation Failed [{Resource:Team Field:data Code:unprocessable Message:Name must be unique for this org}]
│ 
│   with github_team.vng-services-committer,
│   on team.tf line 351, in resource "github_team" "vng-services-committer":
│  351: resource "github_team" "vng-services-committer" {
│ 
╵
Operation failed: failed running terraform apply (exit 1)
```