### PR TITLE
feat: remove PR reviews for assets branch

### DIFF
--- a/documentatie.tf
+++ b/documentatie.tf
@@ -80,11 +80,6 @@ resource "github_branch_protection" "documentatie-assets" {
   allows_deletions        = false
   required_linear_history = true
   allows_force_pushes     = false
-
-  required_pull_request_reviews {
-    dismiss_stale_reviews = true
-    restrict_dismissals   = false
-  }
 }
 
 resource "github_branch_protection" "documentatie-storybook" {


### PR DESCRIPTION
Changes to the "assets" branch do not result in builds by Vercel as configured in `vercel.json` on the "main" branch of the documentatie repository.

PRs *to* the "assets" branch however _do_ result in builds though and those builds will always fail because there is nothing to build on the "assets" branch.