### PR TITLE
feat: improve documentatie branch protection

### DIFF
--- a/documentatie.tf
+++ b/documentatie.tf
@@ -33,7 +33,7 @@ resource "github_branch_protection" "documentatie-main" {
   repository_id = github_repository.documentatie.node_id
 
   pattern                         = "main"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true


### PR DESCRIPTION
Make sure it is no longer possible to accidentally push directly to the `main` branch for admins