### PR TITLE
chore: update branch protections

### DIFF
--- a/denhaag.tf
+++ b/denhaag.tf
@@ -37,7 +37,7 @@ resource "github_branch_protection" "denhaag-main" {
   repository_id = github_repository.denhaag.node_id
 
   pattern                         = "main"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true
@@ -87,7 +87,7 @@ resource "github_branch_protection" "denhaag-www-denhaag-nl" {
   repository_id = github_repository.denhaag.node_id
 
   pattern                         = "www.denhaag.nl"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true

--- a/index.tf
+++ b/index.tf
@@ -31,7 +31,7 @@ resource "github_branch_protection" "index-main" {
   repository_id = github_repository.index.node_id
 
   pattern                         = "main"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true

--- a/lux.tf
+++ b/lux.tf
@@ -38,7 +38,7 @@ resource "github_branch_protection" "lux-main" {
   repository_id = github_repository.lux.node_id
 
   pattern                         = "main"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true

--- a/nldesignsystem-nl-storybook.tf
+++ b/nldesignsystem-nl-storybook.tf
@@ -38,7 +38,7 @@ resource "github_branch_protection" "nldesignsystem-nl-storybook-main" {
   repository_id = github_repository.nldesignsystem-nl-storybook.node_id
 
   pattern                         = "main"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true

--- a/nlds-community-blocks.tf
+++ b/nlds-community-blocks.tf
@@ -24,7 +24,7 @@ resource "github_branch_protection" "nlds-community-blocks-main" {
   repository_id = github_repository.nlds-community-blocks.node_id
 
   pattern                         = "main"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true

--- a/nlds-gravity-forms.tf
+++ b/nlds-gravity-forms.tf
@@ -30,7 +30,7 @@ resource "github_branch_protection" "nlds-gravity-forms-main" {
   repository_id = github_repository.nlds-gravity-forms.node_id
 
   pattern                         = "main"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true

--- a/rijkshuisstijl-community.tf
+++ b/rijkshuisstijl-community.tf
@@ -38,7 +38,7 @@ resource "github_branch_protection" "rijkshuisstijl-community-main" {
   repository_id = github_repository.rijkshuisstijl-community.node_id
 
   pattern                         = "main"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true

--- a/rotterdam.tf
+++ b/rotterdam.tf
@@ -38,7 +38,7 @@ resource "github_branch_protection" "rotterdam-main" {
   repository_id = github_repository.rotterdam.node_id
 
   pattern                         = "main"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true

--- a/rvo.tf
+++ b/rvo.tf
@@ -47,7 +47,7 @@ resource "github_branch_protection" "rvo-master" {
   repository_id = github_repository.rvo.node_id
 
   pattern                         = "master"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true

--- a/services.tf
+++ b/services.tf
@@ -38,7 +38,7 @@ resource "github_branch_protection" "services-main" {
   repository_id = github_repository.services.node_id
 
   pattern                         = "main"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true

--- a/themes.tf
+++ b/themes.tf
@@ -38,7 +38,7 @@ resource "github_branch_protection" "themes-main" {
   repository_id = github_repository.themes.node_id
 
   pattern                         = "main"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true

--- a/tilburg.tf
+++ b/tilburg.tf
@@ -38,7 +38,7 @@ resource "github_branch_protection" "tilburg-main" {
   repository_id = github_repository.tilburg.node_id
 
   pattern                         = "main"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true

--- a/utrecht.tf
+++ b/utrecht.tf
@@ -38,7 +38,7 @@ resource "github_branch_protection" "utrecht-main" {
   repository_id = github_repository.utrecht.node_id
 
   pattern                         = "main"
-  enforce_admins                  = false
+  enforce_admins                  = true
   allows_deletions                = false
   require_signed_commits          = false
   required_linear_history         = true


### PR DESCRIPTION
Set `enforce_admins = true` on all branch protections to prevent accidental pushing to protected branches.