### PR TITLE
chore: add missing kernteam-dependabot

### DIFF
--- a/example.tf
+++ b/example.tf
@@ -90,4 +90,9 @@ resource "github_repository_collaborators" "example" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.slug
   }
+
+  team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.slug
+  }
 }


### PR DESCRIPTION
This should fix this error:

> Reviews may only be requested from collaborators. One or more of the teams you specified is not a collaborator of the nl-design-system/example repository.