### PR TITLE
build: add terraform to dependabot config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+
+root = true
+
+[*]
+charset = UTF-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+trim_trailing_whitespace = true
+
+[*.{md,mdx}]
+trim_trailing_whitespace = false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,15 @@
 version: 2
 
 updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: 'monthly'
-      timezone: 'Europe/Amsterdam'
-      time: '09:00'
+      interval: "monthly"
     reviewers:
-      - 'nl-design-system/kernteam-dependabot'
+      - "nl-design-system/kernteam-dependabot"
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    reviewers:
+      - "nl-design-system/kernteam-dependabot"


### PR DESCRIPTION
Let Dependabot update terraform dependencies monthly.

Remove "timezone" and "time" from "schedule" because they don't do anything for "monthly" intervals.

Add missing `.editorconfig`.