### PR TITLE
chore: add kernteam-dependabot to terraform repo

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -69,6 +69,11 @@ resource "github_repository_collaborators" "terraform" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.slug
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.kernteam-maintainer.slug
   }


### PR DESCRIPTION
This allows Dependabot to assign the kernteam-dependabot members as reviewers for the PR.