### PR TITLE
ci: do not require authentication to access Vercel deployments

### DIFF
--- a/tilburg.tf
+++ b/tilburg.tf
@@ -128,4 +128,8 @@ resource "vercel_project" "tilburg" {
     type = "github"
     repo = "${data.github_organization.nl-design-system.orgname}/${github_repository.tilburg.name}",
   }
+
+  vercel_authentication = {
+    deployment_type = "none"
+  }
 }


### PR DESCRIPTION
@hansregeer merkte op dat er een wachtwoord nodig is om de preview deployment te bekijken, hiermee is dat niet meer nodig.