### PR TITLE
fix: remove bypass_actor from ruleset 

### DIFF
--- a/candidate.tf
+++ b/candidate.tf
@@ -76,12 +76,6 @@ resource "github_repository_ruleset" "candidate-main" {
       }
     }
   }
-
-  bypass_actors {
-    actor_id    = data.github_user.nl-design-system-ci.id
-    actor_type  = "Team"
-    bypass_mode = "always"
-  }
 }
 
 resource "github_repository_collaborators" "candidate" {


### PR DESCRIPTION
For now, remove the bypass_actor from the ruleset to protect the main branch of the candidate repo.

The plan is to get the ruleset in place and then manually add the bypass actor and import that using terraform on the command line.