### PR TITLE
fix: use predefined actor_id for bypass_actors

### DIFF
--- a/candidate.tf
+++ b/candidate.tf
@@ -76,6 +76,12 @@ resource "github_repository_ruleset" "candidate-main" {
       }
     }
   }
+
+  bypass_actors {
+    actor_id    = 5
+    actor_type  = "RepositoryRole"
+    bypass_mode = "always"
+  }
 }
 
 resource "github_repository_collaborators" "candidate" {


### PR DESCRIPTION
> Note: at the time of writing this, the following actor types correspond to the following actor IDs:
>
> - OrganizationAdmin = 1
> - RepositoryRole maintain = 2
> - RepositoryRole write = 4
> - RepositoryRole admin = 5

Source:
https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_ruleset#maintain