### PR TITLE
chore: add kernteam-ci

### DIFF
--- a/candidate.tf
+++ b/candidate.tf
@@ -76,6 +76,12 @@ resource "github_repository_ruleset" "candidate-main" {
       }
     }
   }
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
 }
 
 resource "github_repository_collaborators" "candidate" {

--- a/team-members.tf
+++ b/team-members.tf
@@ -167,6 +167,14 @@ resource "github_team_members" "kernteam-triage" {
   }
 }
 
+resource "github_team_members" "kernteam-ci" {
+  team_id = github_team.kernteam-ci.id
+
+  members {
+    username = data.github_user.nl-design-system-ci.username
+  }
+}
+
 resource "github_team_members" "kernteam-dependabot" {
   team_id = github_team.kernteam-dependabot.id
 

--- a/team.tf
+++ b/team.tf
@@ -26,6 +26,13 @@ resource "github_team" "kernteam-committer" {
   privacy        = "closed"
 }
 
+resource "github_team" "kernteam-ci" {
+  description    = "CI team for nl-design-system-ci that can bypass branch protections"
+  name           = "kernteam-ci"
+  parent_team_id = github_team.kernteam.id
+  privacy        = "closed"
+}
+
 resource "github_team" "kernteam-dependabot" {
   name           = "kernteam-dependabot"
   description    = "Default reviewers for Dependabot pull requests"


### PR DESCRIPTION
Add kernteam-ci as a team with one member (nl-design-system-ci) that is allowed to bypass branch protections on the main branch in the candidate repository.