### PR TITLE
chore: gebruikersonderzoeken collaborators

### DIFF
--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -97,6 +97,11 @@ resource "github_repository_collaborators" "gebruikersonderzoeken" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.slug
+  }
+
+  team {
     permission = "maintain"
     team_id    = github_team.gebruikersonderzoeken.slug
   }


### PR DESCRIPTION
Add `kernteam-dependabot` as a collaborator on the gebruikersonderzoeken repository so Dependabot can request reviews instead of complaining that it cannot.