### PR TITLE
chore: documentatie collaborators

### DIFF
--- a/documentatie.tf
+++ b/documentatie.tf
@@ -120,4 +120,9 @@ resource "github_repository_collaborators" "documentatie" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.slug
   }
+
+  team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.slug
+  }
 }


### PR DESCRIPTION
Add `kernteam-dependabot` as a collaborator on the documentatie repository so Dependabot can request reviews instead of complaining that it cannot.