### PR TITLE
chore(rijkshuisstijl-community): added test-a11y as required status check

### DIFF
--- a/rijkshuisstijl-community.tf
+++ b/rijkshuisstijl-community.tf
@@ -59,7 +59,7 @@ resource "github_branch_protection" "rijkshuisstijl-community-main" {
 
   required_status_checks {
     strict   = false
-    contexts = ["build", "lint", "test"]
+    contexts = ["build", "lint", "test", "test-a11y"]
   }
 
   required_pull_request_reviews {


### PR DESCRIPTION
Change suggested by @JoeriRoijenga 
