### PR TITLE
chore: bump terraform required_version

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -18,7 +18,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.8.0"
+  required_version = "~> 1.10.0"
 }
 
 provider "github" {


### PR DESCRIPTION
@Robbert @Yolijn ik draai lokaal terraform `1.10.4` en heb de setting in Terraform cloud ook aangepast. Jullie zullen dat ook even moeten doen.