### PR TITLE
fix: use team id instead of slug

### DIFF
--- a/backlog.tf
+++ b/backlog.tf
@@ -44,21 +44,21 @@ resource "github_repository_collaborators" "backlog" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 }

--- a/basis.tf
+++ b/basis.tf
@@ -89,26 +89,26 @@ resource "github_repository_collaborators" "basis" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-dependabot.slug
+    team_id    = github_team.kernteam-dependabot.id
   }
 }

--- a/candidate.tf
+++ b/candidate.tf
@@ -89,27 +89,27 @@ resource "github_repository_collaborators" "candidate" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-dependabot.slug
+    team_id    = github_team.kernteam-dependabot.id
   }
 }
 

--- a/denhaag.tf
+++ b/denhaag.tf
@@ -129,51 +129,51 @@ resource "github_repository_collaborators" "denhaag" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "admin"
-    team_id    = github_team.gemeente-denhaag-admin.slug
+    team_id    = github_team.gemeente-denhaag-admin.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-denhaag-design-system.slug
+    team_id    = github_team.gemeente-denhaag-design-system.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-denhaag-acato-committer.slug
+    team_id    = github_team.gemeente-denhaag-acato-committer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.denhaag-acato.slug
+    team_id    = github_team.denhaag-acato.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.frameless.slug
+    team_id    = github_team.frameless.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.frameless-maintainer.slug
+    team_id    = github_team.frameless-maintainer.id
   }
 }

--- a/documentatie.tf
+++ b/documentatie.tf
@@ -103,32 +103,32 @@ resource "github_repository_collaborators" "documentatie" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-a11y.slug
+    team_id    = github_team.kernteam-a11y.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-dependabot.slug
+    team_id    = github_team.kernteam-dependabot.id
   }
 
   team {

--- a/dot-github.tf
+++ b/dot-github.tf
@@ -43,21 +43,21 @@ resource "github_repository_collaborators" "dot-github" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 }

--- a/example-with-angular.tf
+++ b/example-with-angular.tf
@@ -66,26 +66,26 @@ resource "github_repository_collaborators" "example-with-angular" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.frameless.slug
+    team_id    = github_team.frameless.id
   }
 }

--- a/example-with-next-js.tf
+++ b/example-with-next-js.tf
@@ -49,26 +49,26 @@ resource "github_repository_collaborators" "example-with-next-js" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.frameless.slug
+    team_id    = github_team.frameless.id
   }
 }

--- a/example.tf
+++ b/example.tf
@@ -73,26 +73,26 @@ resource "github_repository_collaborators" "example" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-dependabot.slug
+    team_id    = github_team.kernteam-dependabot.id
   }
 }

--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -78,31 +78,31 @@ resource "github_repository_collaborators" "gebruikersonderzoeken" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-dependabot.slug
+    team_id    = github_team.kernteam-dependabot.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.gebruikersonderzoeken.slug
+    team_id    = github_team.gebruikersonderzoeken.id
   }
 }

--- a/icons.tf
+++ b/icons.tf
@@ -67,27 +67,27 @@ resource "github_repository_collaborators" "icons" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.icons-committer.slug
+    team_id    = github_team.icons-committer.id
   }
 }
 

--- a/index.tf
+++ b/index.tf
@@ -65,21 +65,21 @@ resource "github_repository_collaborators" "index" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 }

--- a/lux.tf
+++ b/lux.tf
@@ -85,31 +85,31 @@ resource "github_repository_collaborators" "lux" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.logius-committer.slug
+    team_id    = github_team.logius-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.logius-triage.slug
+    team_id    = github_team.logius-triage.id
   }
 }

--- a/matomo.tf
+++ b/matomo.tf
@@ -51,21 +51,21 @@ resource "github_repository_collaborators" "matomo" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 }

--- a/mendix.tf
+++ b/mendix.tf
@@ -83,36 +83,36 @@ resource "github_repository_collaborators" "mendix" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-dependabot.slug
+    team_id    = github_team.kernteam-dependabot.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-rotterdam-committer.slug
+    team_id    = github_team.gemeente-rotterdam-committer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.frameless.slug
+    team_id    = github_team.frameless.id
   }
 }

--- a/nldesignsystem-nl-storybook.tf
+++ b/nldesignsystem-nl-storybook.tf
@@ -82,21 +82,21 @@ resource "github_repository_collaborators" "kernteam-admin" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 }

--- a/nlds-community-blocks.tf
+++ b/nlds-community-blocks.tf
@@ -58,31 +58,31 @@ resource "github_repository_collaborators" "nlds-community-blocks" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.denhaag-draad.slug
+    team_id    = github_team.denhaag-draad.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.denhaag-acato.slug
+    team_id    = github_team.denhaag-acato.id
   }
 }

--- a/nlds-gravity-forms.tf
+++ b/nlds-gravity-forms.tf
@@ -64,26 +64,26 @@ resource "github_repository_collaborators" "nlds-gravity-forms" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gravityforms.slug
+    team_id    = github_team.gravityforms.id
   }
 }

--- a/publiccode-parser-action.tf
+++ b/publiccode-parser-action.tf
@@ -44,21 +44,21 @@ resource "github_repository_collaborators" "publiccode-parser-action" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 }

--- a/rijkshuisstijl-community.tf
+++ b/rijkshuisstijl-community.tf
@@ -86,47 +86,47 @@ resource "github_repository_collaborators" "rijkshuisstijl-community" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.logius.slug
+    team_id    = github_team.logius.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.rivm.slug
+    team_id    = github_team.rivm.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.rvo.slug
+    team_id    = github_team.rvo.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.quintor-rijkshuisstijl-committer.slug
+    team_id    = github_team.quintor-rijkshuisstijl-committer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.minjus-rijkshuisstijl-committer.slug
+    team_id    = github_team.minjus-rijkshuisstijl-committer.id
   }
 }
 

--- a/rotterdam.tf
+++ b/rotterdam.tf
@@ -82,46 +82,46 @@ resource "github_repository_collaborators" "rotterdam" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.gemeente-rotterdam-maintainer.slug
+    team_id    = github_team.gemeente-rotterdam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-rotterdam-committer.slug
+    team_id    = github_team.gemeente-rotterdam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.gemeente-rotterdam-triage.slug
+    team_id    = github_team.gemeente-rotterdam-triage.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.frameless.slug
+    team_id    = github_team.frameless.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.frameless-maintainer.slug
+    team_id    = github_team.frameless-maintainer.id
   }
 }

--- a/rvo.tf
+++ b/rvo.tf
@@ -96,31 +96,31 @@ resource "github_repository_collaborators" "rvo" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.rvo-committer.slug
+    team_id    = github_team.rvo-committer.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.rvo-maintainer.slug
+    team_id    = github_team.rvo-maintainer.id
   }
 }

--- a/services.tf
+++ b/services.tf
@@ -75,37 +75,37 @@ resource "github_repository_collaborators" "services" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.vng-services-committer.slug
+    team_id    = github_team.vng-services-committer.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.vng-services-maintainer.slug
+    team_id    = github_team.vng-services-maintainer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.vng-services.slug
+    team_id    = github_team.vng-services.id
   }
 }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -65,69 +65,69 @@ resource "github_repository_collaborators" "terraform" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-dependabot.slug
+    team_id    = github_team.kernteam-dependabot.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   # Allow maintainers of community teams to make PRs and review PRs
   team {
     permission = "push"
-    team_id    = github_team.frameless-maintainer.slug
+    team_id    = github_team.frameless-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.logius-maintainer.slug
+    team_id    = github_team.logius-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.rvo-maintainer.slug
+    team_id    = github_team.rvo-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.tilburg-acato-maintainer.slug
+    team_id    = github_team.tilburg-acato-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.tilburg-ditp-maintainer.slug
+    team_id    = github_team.tilburg-ditp-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.quintor-rijkshuisstijl-maintainer.slug
+    team_id    = github_team.quintor-rijkshuisstijl-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.blueriq-maintainer.slug
+    team_id    = github_team.blueriq-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-rotterdam-maintainer.slug
+    team_id    = github_team.gemeente-rotterdam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.vng-services-maintainer.slug
+    team_id    = github_team.vng-services-maintainer.id
   }
 
   # Restrict pushes to infrastructure as code to admins and maintainers
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 }

--- a/themes.tf
+++ b/themes.tf
@@ -82,186 +82,186 @@ resource "github_repository_collaborators" "themes" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-amsterdam.slug
+    team_id    = github_team.gemeente-amsterdam.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-bodegraven-reeuwijk.slug
+    team_id    = github_team.gemeente-bodegraven-reeuwijk.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-bodegraven-reeuwijk.slug
+    team_id    = github_team.gemeente-bodegraven-reeuwijk.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-borne.slug
+    team_id    = github_team.gemeente-borne.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-buren.slug
+    team_id    = github_team.gemeente-buren.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-den-haag.slug
+    team_id    = github_team.gemeente-den-haag.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-drechterland.slug
+    team_id    = github_team.gemeente-drechterland.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-duiven.slug
+    team_id    = github_team.gemeente-duiven.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-enkhuizen.slug
+    team_id    = github_team.gemeente-enkhuizen.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-groningen.slug
+    team_id    = github_team.gemeente-groningen.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-haarlem.slug
+    team_id    = github_team.gemeente-haarlem.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-hoorn.slug
+    team_id    = github_team.gemeente-hoorn.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-horst-aan-de-maas.slug
+    team_id    = github_team.gemeente-horst-aan-de-maas.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-leidschendam-voorburg.slug
+    team_id    = github_team.gemeente-leidschendam-voorburg.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-nijmegen.slug
+    team_id    = github_team.gemeente-nijmegen.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-noordoostpolder.slug
+    team_id    = github_team.gemeente-noordoostpolder.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-stedebroec.slug
+    team_id    = github_team.gemeente-stedebroec.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-tilburg.slug
+    team_id    = github_team.gemeente-tilburg.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-utrecht.slug
+    team_id    = github_team.gemeente-utrecht.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-venray.slug
+    team_id    = github_team.gemeente-venray.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-vught.slug
+    team_id    = github_team.gemeente-vught.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-westervoort.slug
+    team_id    = github_team.gemeente-westervoort.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-zevenaar.slug
+    team_id    = github_team.gemeente-zevenaar.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-zwolle.slug
+    team_id    = github_team.gemeente-zwolle.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.rid-de-liemers.slug
+    team_id    = github_team.rid-de-liemers.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.provincie-zuid-holland.slug
+    team_id    = github_team.provincie-zuid-holland.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.minaz-1overheid.slug
+    team_id    = github_team.minaz-1overheid.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.frameless.slug
+    team_id    = github_team.frameless.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.logius.slug
+    team_id    = github_team.logius.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.voorbeeld-theme-committer.slug
+    team_id    = github_team.voorbeeld-theme-committer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.vng-services-committer.slug
+    team_id    = github_team.vng-services-committer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-almere-committer.slug
+    team_id    = github_team.gemeente-almere-committer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.nora-committer.slug
+    team_id    = github_team.nora-committer.id
   }
 }

--- a/tilburg.tf
+++ b/tilburg.tf
@@ -85,37 +85,37 @@ resource "github_repository_collaborators" "tilburg" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.tilburg-acato-committer.slug
+    team_id    = github_team.tilburg-acato-committer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.tilburg-ditp-committer.slug
+    team_id    = github_team.tilburg-ditp-committer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.blueriq-committer.slug
+    team_id    = github_team.blueriq-committer.id
   }
 }
 

--- a/tiptap.tf
+++ b/tiptap.tf
@@ -89,32 +89,32 @@ resource "github_repository_collaborators" "tiptap" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-dependabot.slug
+    team_id    = github_team.kernteam-dependabot.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.tiptap-committer.slug
+    team_id    = github_team.tiptap-committer.id
   }
 }
 

--- a/utrecht.tf
+++ b/utrecht.tf
@@ -69,46 +69,46 @@ resource "github_repository_collaborators" "utrecht" {
 
   team {
     permission = "admin"
-    team_id    = github_team.kernteam-admin.slug
+    team_id    = github_team.kernteam-admin.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.kernteam-maintainer.slug
+    team_id    = github_team.kernteam-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.kernteam-committer.slug
+    team_id    = github_team.kernteam-committer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.kernteam-triage.slug
+    team_id    = github_team.kernteam-triage.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.gemeente-utrecht.slug
+    team_id    = github_team.gemeente-utrecht.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.frameless.slug
+    team_id    = github_team.frameless.id
   }
 
   team {
     permission = "maintain"
-    team_id    = github_team.frameless-maintainer.slug
+    team_id    = github_team.frameless-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id    = github_team.logius-maintainer.slug
+    team_id    = github_team.logius-maintainer.id
   }
 
   team {
     permission = "triage"
-    team_id    = github_team.logius-triage.slug
+    team_id    = github_team.logius-triage.id
   }
 }


### PR DESCRIPTION
For github_repository_collaborators team blocks, use the id instead of the slug