### PR TITLE
fix: reduce churn

### DIFF
--- a/basis.tf
+++ b/basis.tf
@@ -31,10 +31,6 @@ resource "github_repository" "basis" {
     }
   }
 
-  pages {
-    build_type = "workflow"
-  }
-
   lifecycle {
     prevent_destroy = true
   }

--- a/candidate.tf
+++ b/candidate.tf
@@ -33,6 +33,12 @@ resource "github_repository" "candidate" {
 
   pages {
     build_type = "workflow"
+
+    # A `source` block is only needed when `build_type` is set to `"legacy"`, but because GitHub keeps it around invisibly, we must add it here to prevent churn
+    source {
+      branch = "main"
+      path   = "/"
+    }
   }
 
   lifecycle {

--- a/example.tf
+++ b/example.tf
@@ -28,6 +28,12 @@ resource "github_repository" "example" {
 
   pages {
     build_type = "workflow"
+
+    # A `source` block is only needed when `build_type` is set to `"legacy"`, but because GitHub keeps it around invisibly, we must add it here to prevent churn
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
   }
 
   lifecycle {

--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -25,6 +25,12 @@ resource "github_repository" "gebruikersonderzoeken" {
   pages {
     build_type = "workflow"
     cname      = "gebruikersonderzoeken.nl"
+
+    # A `source` block is only needed when `build_type` is set to `"legacy"`, but because GitHub keeps it around invisibly, we must add it here to prevent churn
+    source {
+      branch = "main"
+      path   = "/"
+    }
   }
 
   lifecycle {

--- a/mendix.tf
+++ b/mendix.tf
@@ -27,6 +27,12 @@ resource "github_repository" "mendix" {
 
   pages {
     build_type = "workflow"
+
+    # A `source` block is only needed when `build_type` is set to `"legacy"`, but because GitHub keeps it around invisibly, we must add it here to prevent churn
+    source {
+      branch = "main"
+      path   = "/"
+    }
   }
 
   lifecycle {

--- a/tiptap.tf
+++ b/tiptap.tf
@@ -33,6 +33,12 @@ resource "github_repository" "tiptap" {
 
   pages {
     build_type = "workflow"
+
+    # A `source` block is only needed when `build_type` is set to `"legacy"`, but because GitHub keeps it around invisibly, we must add it here to prevent churn
+    source {
+      branch = "main"
+      path   = "/"
+    }
   }
 
   lifecycle {

--- a/utrecht.tf
+++ b/utrecht.tf
@@ -24,6 +24,12 @@ resource "github_repository" "utrecht" {
 
   pages {
     build_type = "workflow"
+
+    # A `source` block is only needed when `build_type` is set to `"legacy"`, but because GitHub keeps it around invisibly, we must add it here to prevent churn
+    source {
+      branch = "gh-pages"
+      path   = "/"
+    }
   }
 
   lifecycle {


### PR DESCRIPTION
Prevent unnecessary "changes" by adding the "source" block that GitHub keeps around invisibly in the background.

See this example from an API call to the pages endpoint of the candidate repository. `"source"` is still present even though `"build_type"` is set to `"workflow"`.

```json
{
  "url":
    "https://api.github.com/repos/nl-design-system/candidate/pages",
    "status": null,
    "cname": null,
    "custom_404": false,
    "html_url": "https://nl-design-system.github.io/candidate/",
    "build_type": "workflow",
    "source": {
      "branch": "main",
      "path": "/"
    },
    "public": true,
    "protected_domain_state": null,
    "pending_domain_unverified_at": null,
    "https_enforced": true
}
```