### PR TITLE
chore: gebruikersonderzoeken gh-pages

### DIFF
--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -28,7 +28,7 @@ resource "github_repository" "gebruikersonderzoeken" {
 
     # A `source` block is only needed when `build_type` is set to `"legacy"`, but because GitHub keeps it around invisibly, we must add it here to prevent churn
     source {
-      branch = "main"
+      branch = "gh-pages"
       path   = "/"
     }
   }


### PR DESCRIPTION
The GitHub REST API shows the following for the GH Pages configuration:

```json
"source": {
  "branch": "gh-pages",
  "path": "/"
}
```

To reduce churn, we'll match that here even though it does not really make sense since we use GitHub Actions as the source instead of deploying from a branch.