### PR TITLE
chore: allow Quintor committers to push to themes

### DIFF
--- a/themes.tf
+++ b/themes.tf
@@ -264,4 +264,9 @@ resource "github_repository_collaborators" "themes" {
     permission = "push"
     team_id    = github_team.nora-committer.id
   }
+
+  team {
+    permission = "push"
+    team_id    = github_team.quintor-rijkshuisstijl-committer.id
+  }
 }


### PR DESCRIPTION
Mijn aanname is dat alle Quintor committers toegang krijgen. Klopt dit?