### PR TITLE
chore: remove Candidate GitHub Pages config

### DIFF
--- a/candidate.tf
+++ b/candidate.tf
@@ -31,16 +31,6 @@ resource "github_repository" "candidate" {
     }
   }
 
-  pages {
-    build_type = "workflow"
-
-    # A `source` block is only needed when `build_type` is set to `"legacy"`, but because GitHub keeps it around invisibly, we must add it here to prevent churn
-    source {
-      branch = "main"
-      path   = "/"
-    }
-  }
-
   lifecycle {
     prevent_destroy = true
   }


### PR DESCRIPTION
After this run, there should ideally no longer be a GitHub Pages setup for the Candidate repo.

We'll re-add it without the `source` block to see if that gets rid of churn permanently.