### PR TITLE
chore: re-add Candidate pages

### DIFF
--- a/candidate.tf
+++ b/candidate.tf
@@ -22,6 +22,10 @@ resource "github_repository" "candidate" {
     include_all_branches = false
   }
 
+  pages {
+    build_type = "workflow"
+  }
+
   security_and_analysis {
     secret_scanning {
       status = "enabled"


### PR DESCRIPTION
Re-add the Candidate pages block, but now without a `source` block