### PR TITLE
chore: prevent churn

### DIFF
--- a/candidate.tf
+++ b/candidate.tf
@@ -24,6 +24,12 @@ resource "github_repository" "candidate" {
 
   pages {
     build_type = "workflow"
+
+    # A `source` block is only needed when `build_type` is set to `"legacy"`, but because GitHub keeps it around invisibly, we must add it here to prevent churn
+    source {
+      branch = "main"
+      path   = "/"
+    }
   }
 
   security_and_analysis {


### PR DESCRIPTION
Re-add the `source` block for pages in the "candidate" repo to prevent churn