### PR TITLE
chore: add kernteam-dependabot to "index" repo

### DIFF
--- a/index.tf
+++ b/index.tf
@@ -82,4 +82,9 @@ resource "github_repository_collaborators" "index" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
+
+  team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
 }


### PR DESCRIPTION
Allow the "kernteam-dependabot" team to triage the "index" repository.