### PR TITLE
chore: add missing kernteam-dependabot

### DIFF
--- a/denhaag.tf
+++ b/denhaag.tf
@@ -148,6 +148,11 @@ resource "github_repository_collaborators" "denhaag" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "admin"
     team_id    = github_team.gemeente-denhaag-admin.id
   }

--- a/icons.tf
+++ b/icons.tf
@@ -86,6 +86,11 @@ resource "github_repository_collaborators" "icons" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.icons-committer.id
   }

--- a/nldesignsystem-nl-storybook.tf
+++ b/nldesignsystem-nl-storybook.tf
@@ -99,4 +99,9 @@ resource "github_repository_collaborators" "kernteam-admin" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
+
+  team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
 }

--- a/nlds-gravity-forms.tf
+++ b/nlds-gravity-forms.tf
@@ -83,6 +83,11 @@ resource "github_repository_collaborators" "nlds-gravity-forms" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.gravityforms.id
   }

--- a/rotterdam.tf
+++ b/rotterdam.tf
@@ -101,6 +101,11 @@ resource "github_repository_collaborators" "rotterdam" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "maintain"
     team_id    = github_team.gemeente-rotterdam-maintainer.id
   }

--- a/rvo.tf
+++ b/rvo.tf
@@ -115,6 +115,11 @@ resource "github_repository_collaborators" "rvo" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.rvo-committer.id
   }

--- a/services.tf
+++ b/services.tf
@@ -94,6 +94,11 @@ resource "github_repository_collaborators" "services" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.vng-services-committer.id
   }

--- a/themes.tf
+++ b/themes.tf
@@ -101,6 +101,11 @@ resource "github_repository_collaborators" "themes" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.gemeente-amsterdam.id
   }

--- a/tilburg.tf
+++ b/tilburg.tf
@@ -111,6 +111,11 @@ resource "github_repository_collaborators" "tilburg" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.tilburg-acato-committer.id
   }

--- a/utrecht.tf
+++ b/utrecht.tf
@@ -94,6 +94,11 @@ resource "github_repository_collaborators" "utrecht" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "maintain"
     team_id    = github_team.gemeente-utrecht.id
   }


### PR DESCRIPTION
To all repositories where Dependabot wants to ask kernteam-dependabot for a review