### PR TITLE
fix: denhaag churn

### DIFF
--- a/denhaag.tf
+++ b/denhaag.tf
@@ -15,12 +15,6 @@ resource "github_repository" "denhaag" {
   squash_merge_commit_message = "PR_BODY"
   topics                      = ["nl-design-system", "storybook", "react", "component-library"]
 
-  template {
-    include_all_branches = false
-    owner                = "nl-design-system"
-    repository           = "example"
-  }
-
   pages {
     source {
       branch = "gh-pages"


### PR DESCRIPTION
The "denhaag" repository was not created using "example" as a template so trying to add a `template` block causes churn.