### PR TITLE
fix: include patterns

### DIFF
--- a/documentatie.tf
+++ b/documentatie.tf
@@ -87,9 +87,9 @@ resource "github_repository_ruleset" "documentatie-other" {
   conditions {
     ref_name {
       include = [
-        "gh-pages",
-        "assets",
-        "storybook",
+        "refs/heads/gh-pages",
+        "refs/heads/assets",
+        "refs/heads/storybook",
       ]
       exclude = []
     }


### PR DESCRIPTION
simply using branch names does not work. For the main branch we used refs/heads/main, so use that for these branches as well.