### PR TITLE
Clean up rulesets

### DIFF
--- a/backlog.tf
+++ b/backlog.tf
@@ -40,7 +40,7 @@ resource "github_repository_ruleset" "backlog-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/basis.tf
+++ b/basis.tf
@@ -78,6 +78,8 @@ resource "github_repository_ruleset" "basis-main" {
     }
 
     required_status_checks {
+      strict_required_status_checks_policy = true
+
       required_check {
         context = "build"
       }

--- a/basis.tf
+++ b/basis.tf
@@ -61,7 +61,7 @@ resource "github_repository_ruleset" "basis-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/candidate.tf
+++ b/candidate.tf
@@ -71,7 +71,7 @@ resource "github_repository_ruleset" "candidate-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/candidate.tf
+++ b/candidate.tf
@@ -88,6 +88,8 @@ resource "github_repository_ruleset" "candidate-main" {
     }
 
     required_status_checks {
+      strict_required_status_checks_policy = true
+
       required_check {
         context = "build"
       }
@@ -99,6 +101,9 @@ resource "github_repository_ruleset" "candidate-main" {
       }
       required_check {
         context = "test"
+      }
+      required_check {
+        context = "Block Autosquash Commits"
       }
     }
   }

--- a/denhaag.tf
+++ b/denhaag.tf
@@ -69,7 +69,6 @@ resource "github_repository_ruleset" "denhaag-main" {
     }
 
     required_status_checks {
-      do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
 
       required_check {
@@ -119,7 +118,6 @@ resource "github_repository_ruleset" "denhaag-www-denhaag-nl" {
     }
 
     required_status_checks {
-      do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
 
       required_check {

--- a/documentatie.tf
+++ b/documentatie.tf
@@ -54,7 +54,7 @@ resource "github_repository_ruleset" "documentatie-default" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true
@@ -95,7 +95,7 @@ resource "github_repository_ruleset" "documentatie-other" {
     }
   }
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/documentatie.tf
+++ b/documentatie.tf
@@ -71,6 +71,8 @@ resource "github_repository_ruleset" "documentatie-default" {
     }
 
     required_status_checks {
+      strict_required_status_checks_policy = false
+
       required_check {
         context = "continuous-integration"
       }

--- a/dot-github.tf
+++ b/dot-github.tf
@@ -35,7 +35,7 @@ resource "github_repository_ruleset" "dot-github-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/example.tf
+++ b/example.tf
@@ -77,7 +77,6 @@ resource "github_repository_ruleset" "example-main" {
     }
 
     required_status_checks {
-      do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
 
       required_check {

--- a/example.tf
+++ b/example.tf
@@ -60,7 +60,7 @@ resource "github_repository_ruleset" "example-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -57,7 +57,7 @@ resource "github_repository_ruleset" "gebruikersonderzoeken-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -74,7 +74,6 @@ resource "github_repository_ruleset" "gebruikersonderzoeken-main" {
     }
 
     required_status_checks {
-      do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
 
       required_check {

--- a/hall-of-fame.tf_
+++ b/hall-of-fame.tf_
@@ -84,6 +84,8 @@ resource "github_repository_ruleset" "hall-of-fame-main" {
     }
 
     required_status_checks {
+      strict_required_status_checks_policy = false
+
       required_check {
         context = "build"
       }

--- a/hall-of-fame.tf_
+++ b/hall-of-fame.tf_
@@ -67,7 +67,7 @@ resource "github_repository_ruleset" "hall-of-fame-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/icons.tf
+++ b/icons.tf
@@ -63,7 +63,6 @@ resource "github_repository_ruleset" "cons-main" {
     }
 
     required_status_checks {
-      do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
 
       required_check {

--- a/icons.tf
+++ b/icons.tf
@@ -46,7 +46,7 @@ resource "github_repository_ruleset" "cons-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/index.tf
+++ b/index.tf
@@ -52,7 +52,7 @@ resource "github_repository_ruleset" "index-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/index.tf
+++ b/index.tf
@@ -69,7 +69,6 @@ resource "github_repository_ruleset" "index-main" {
     }
 
     required_status_checks {
-      do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
 
       required_check {

--- a/lux.tf
+++ b/lux.tf
@@ -76,7 +76,6 @@ resource "github_repository_ruleset" "lux-main" {
     }
 
     required_status_checks {
-      do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
 
       required_check {

--- a/lux.tf
+++ b/lux.tf
@@ -59,7 +59,7 @@ resource "github_repository_ruleset" "lux-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true
@@ -110,7 +110,7 @@ resource "github_repository_ruleset" "lux-other" {
     }
   }
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/matomo.tf
+++ b/matomo.tf
@@ -47,7 +47,7 @@ resource "github_repository_ruleset" "matomo-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/mendix.tf
+++ b/mendix.tf
@@ -73,6 +73,8 @@ resource "github_repository_ruleset" "mendix-main" {
     required_linear_history = true
 
     required_status_checks {
+      strict_required_status_checks_policy = false
+
       required_check {
         context = "build"
       }

--- a/nldesignsystem-nl-storybook.tf
+++ b/nldesignsystem-nl-storybook.tf
@@ -59,7 +59,7 @@ resource "github_repository_ruleset" "nldesignsystem-nl-storybook-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true
@@ -107,7 +107,7 @@ resource "github_repository_ruleset" "nldesignsystem-nl-storybook-other" {
     }
   }
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/nldesignsystem-nl-storybook.tf
+++ b/nldesignsystem-nl-storybook.tf
@@ -76,6 +76,8 @@ resource "github_repository_ruleset" "nldesignsystem-nl-storybook-main" {
     }
 
     required_status_checks {
+      strict_required_status_checks_policy = false
+
       required_check {
         context = "build"
       }

--- a/nlds-community-blocks.tf
+++ b/nlds-community-blocks.tf
@@ -45,7 +45,7 @@ resource "github_repository_ruleset" "nlds-community-blocks-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/nlds-community-blocks.tf
+++ b/nlds-community-blocks.tf
@@ -62,6 +62,8 @@ resource "github_repository_ruleset" "nlds-community-blocks-main" {
     }
 
     required_status_checks {
+      strict_required_status_checks_policy = false
+
       required_check {
         context = "build"
       }

--- a/nlds-gravity-forms.tf
+++ b/nlds-gravity-forms.tf
@@ -51,7 +51,7 @@ resource "github_repository_ruleset" "nlds-gravity-forms-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/nlds-gravity-forms.tf
+++ b/nlds-gravity-forms.tf
@@ -68,6 +68,8 @@ resource "github_repository_ruleset" "nlds-gravity-forms-main" {
     }
 
     required_status_checks {
+      strict_required_status_checks_policy = false
+
       required_check {
         context = "build"
       }

--- a/overheidsbrede-portalen-community.tf
+++ b/overheidsbrede-portalen-community.tf
@@ -53,7 +53,7 @@ resource "github_repository_ruleset" "overheidsbrede-portalen-community-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/overheidsbrede-portalen-community.tf
+++ b/overheidsbrede-portalen-community.tf
@@ -70,7 +70,6 @@ resource "github_repository_ruleset" "overheidsbrede-portalen-community-main" {
     }
 
     required_status_checks {
-      do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
 
       required_check {

--- a/publiccode-parser-action.tf
+++ b/publiccode-parser-action.tf
@@ -39,7 +39,7 @@ resource "github_repository_ruleset" "publiccode-parser-action-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/rijkshuisstijl-community.tf
+++ b/rijkshuisstijl-community.tf
@@ -76,7 +76,6 @@ resource "github_repository_ruleset" "rijkshuisstijl-community-main" {
     }
 
     required_status_checks {
-      do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
 
       required_check {

--- a/rotterdam.tf
+++ b/rotterdam.tf
@@ -76,7 +76,6 @@ resource "github_repository_ruleset" "rotterdam-main" {
     }
 
     required_status_checks {
-      do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
 
       required_check {

--- a/theme-builder.tf
+++ b/theme-builder.tf
@@ -52,7 +52,7 @@ resource "github_repository_ruleset" "theme-builder-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/themes.tf
+++ b/themes.tf
@@ -79,7 +79,6 @@ resource "github_repository_ruleset" "themes-main" {
     }
 
     required_status_checks {
-      do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
 
       required_check {

--- a/themes.tf
+++ b/themes.tf
@@ -62,7 +62,7 @@ resource "github_repository_ruleset" "themes-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/tilburg.tf
+++ b/tilburg.tf
@@ -56,7 +56,7 @@ resource "github_repository_ruleset" "tilburg-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/tilburg.tf
+++ b/tilburg.tf
@@ -73,7 +73,6 @@ resource "github_repository_ruleset" "tilburg-main" {
     }
 
     required_status_checks {
-      do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
 
       required_check {

--- a/tiptap.tf
+++ b/tiptap.tf
@@ -88,6 +88,8 @@ resource "github_repository_ruleset" "tiptap-main" {
     }
 
     required_status_checks {
+      strict_required_status_checks_policy = false
+
       required_check {
         context = "build"
       }

--- a/tiptap.tf
+++ b/tiptap.tf
@@ -71,7 +71,7 @@ resource "github_repository_ruleset" "tiptap-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true

--- a/utrecht.tf
+++ b/utrecht.tf
@@ -81,6 +81,7 @@ resource "github_repository_ruleset" "utrecht-main" {
     required_status_checks {
       strict_required_status_checks_policy = false
 
+
       required_check {
         context = "build"
       }

--- a/wcag-statistieken.tf
+++ b/wcag-statistieken.tf
@@ -65,7 +65,7 @@ resource "github_repository_ruleset" "wcag-statistieken-main" {
   }
 
   rules {
-    creation                      = true
+    creation                      = false
     deletion                      = true
     non_fast_forward              = true
     required_linear_history       = true


### PR DESCRIPTION
- Set rules.creation to false; branches have already been created and need no protection from being created.
- Remove do_not_enforce_on_create = false from required_status_checks as it's always set to the default `false` and it's irrelevant for existing branches
- Add missing strict_required_status_checks_policy where needed and set it to `true` in "basis" and "candidate"