### PR TITLE
chore: add missing kernteam-dependabot

### DIFF
--- a/dot-github.tf
+++ b/dot-github.tf
@@ -75,4 +75,9 @@ resource "github_repository_collaborators" "dot-github" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
+
+  team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
 }

--- a/example-with-angular.tf
+++ b/example-with-angular.tf
@@ -90,6 +90,11 @@ resource "github_repository_collaborators" "example-with-angular" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.frameless.id
   }

--- a/matomo.tf
+++ b/matomo.tf
@@ -86,4 +86,9 @@ resource "github_repository_collaborators" "matomo" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
+
+  team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
 }

--- a/nlds-community-blocks.tf
+++ b/nlds-community-blocks.tf
@@ -107,6 +107,11 @@ resource "github_repository_collaborators" "nlds-community-blocks" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.denhaag-draad.id
   }

--- a/publiccode-parser-action.tf
+++ b/publiccode-parser-action.tf
@@ -77,4 +77,9 @@ resource "github_repository_collaborators" "publiccode-parser-action" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
+
+  team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
 }

--- a/rijkshuisstijl-community.tf
+++ b/rijkshuisstijl-community.tf
@@ -141,6 +141,11 @@ resource "github_repository_collaborators" "rijkshuisstijl-community" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.frameless.id
   }

--- a/theme-builder.tf
+++ b/theme-builder.tf
@@ -91,6 +91,11 @@ resource "github_repository_collaborators" "theme-builder" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.expertteam-digitale-toegankelijkheid-committer.id
   }

--- a/wcag-statistieken.tf
+++ b/wcag-statistieken.tf
@@ -97,6 +97,11 @@ resource "github_repository_collaborators" "wcag-statistieken" {
   }
 
   team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.expertteam-digitale-toegankelijkheid-committer.id
   }


### PR DESCRIPTION
Add kernteam-dependabot as a collaborator on all repos that did not have it already