### PR TITLE
feat: add architectuur repo

### DIFF
--- a/architectuur.tf
+++ b/architectuur.tf
@@ -1,0 +1,108 @@
+resource "github_repository" "architectuur" {
+  name                        = "architectuur"
+  description                 = "NL Design System architectuur"
+  allow_merge_commit          = false
+  allow_rebase_merge          = true
+  allow_squash_merge          = true
+  allow_auto_merge            = true
+  delete_branch_on_merge      = true
+  has_issues                  = true
+  has_downloads               = false
+  has_projects                = false
+  has_wiki                    = false
+  vulnerability_alerts        = true
+  homepage_url                = "https://nl-design-system.github.io/architectuur/"
+  squash_merge_commit_title   = "PR_TITLE"
+  squash_merge_commit_message = "PR_BODY"
+  topics                      = ["nl-design-system"]
+
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_branch_default" "architectuur" {
+  repository = github_repository.architectuur.name
+  branch     = "main"
+}
+
+resource "github_repository_ruleset" "architectuur-main" {
+  enforcement = "active"
+  name        = "default-branch-protection"
+  repository  = github_repository.architectuur.name
+  target      = "branch"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                      = false
+    deletion                      = true
+    non_fast_forward              = true
+    required_linear_history       = true
+    required_signatures           = false
+    update                        = false
+    update_allows_fetch_and_merge = false
+
+    pull_request {
+      dismiss_stale_reviews_on_push     = true
+      require_code_owner_review         = true
+      require_last_push_approval        = false
+      required_approving_review_count   = 0
+      required_review_thread_resolution = true
+    }
+  }
+}
+
+resource "github_repository_collaborators" "architectuur" {
+  repository = github_repository.architectuur.name
+
+  team {
+    permission = "admin"
+    team_id    = github_team.kernteam-admin.id
+  }
+
+  team {
+    permission = "maintain"
+    team_id    = github_team.kernteam-maintainer.id
+  }
+
+  team {
+    permission = "push"
+    team_id    = github_team.kernteam-committer.id
+  }
+
+  team {
+    permission = "triage"
+    team_id    = github_team.kernteam-triage.id
+  }
+
+  team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
+    permission = "push"
+    team_id    = github_team.expertteam-digitale-toegankelijkheid-committer.id
+  }
+}


### PR DESCRIPTION
Een nieuwe repo voor archimate-bestanden en GitHub Pages om ze in HTML te laten zien.

- gekopieerd van `basis`
- expertteam toegevoegd met push-rechten
- required checks uitgezet, in eerste instantie is er nog geen npm-setup
- required review uitgezet, omdat dit voornamelijk solitair werk is en geen risico voor productie-omgevingen heeft
- Nederlandstalig omdat de architectuur-documentatie volledig Nederlands is