### PR TITLE
chore: add changeset-status check

### DIFF
--- a/candidate.tf
+++ b/candidate.tf
@@ -105,6 +105,9 @@ resource "github_repository_ruleset" "candidate-main" {
       required_check {
         context = "Block Autosquash Commits"
       }
+      required_check {
+        context = "changeset-status"
+      }
     }
   }
 }


### PR DESCRIPTION
Make the changeset-status check a required check for the candidate repository.

This will make sure that Dependabot pull requests cannot be merged because they will always lack a changeset.

For `dependabot/npm_and_yarn/*` PRs this is desirable because they should not be merged.

For `dependabot/github_actions/*` PRs this means that an empty changeset will have to be added before they can be merged.