### PR TITLE
fix: checks for gebruikersonderzoeken

### DIFF
--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -77,11 +77,11 @@ resource "github_repository_ruleset" "gebruikersonderzoeken-main" {
       strict_required_status_checks_policy = false
 
       required_check {
-        context = "Lint code"
+        context = "lint"
       }
 
       required_check {
-        context = "Build"
+        context = "build"
       }
     }
   }


### PR DESCRIPTION
The `name` keys were removed so just use the lowercase names of the actual jobs.