### PR TITLE
chore: update teams

### DIFF
--- a/architectuur.tf
+++ b/architectuur.tf
@@ -127,11 +127,6 @@ resource "github_repository_collaborators" "architectuur" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.expertteam-digitale-toegankelijkheid-committer.id
   }

--- a/basis.tf
+++ b/basis.tf
@@ -121,9 +121,4 @@ resource "github_repository_collaborators" "basis" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
-
-  team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
 }

--- a/candidate.tf
+++ b/candidate.tf
@@ -134,11 +134,6 @@ resource "github_repository_collaborators" "candidate" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
-
-  team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
 }
 
 resource "vercel_project" "candidate" {

--- a/denhaag.tf
+++ b/denhaag.tf
@@ -177,11 +177,6 @@ resource "github_repository_collaborators" "denhaag" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "admin"
     team_id    = github_team.gemeente-denhaag-admin.id
   }

--- a/documentatie.tf
+++ b/documentatie.tf
@@ -136,11 +136,6 @@ resource "github_repository_collaborators" "documentatie" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.community-committer.id
   }

--- a/dot-github.tf
+++ b/dot-github.tf
@@ -75,9 +75,4 @@ resource "github_repository_collaborators" "dot-github" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
-
-  team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
 }

--- a/example-with-angular.tf
+++ b/example-with-angular.tf
@@ -121,11 +121,6 @@ resource "github_repository_collaborators" "example-with-angular" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.frameless.id
   }

--- a/example.tf
+++ b/example.tf
@@ -120,9 +120,4 @@ resource "github_repository_collaborators" "example" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
-
-  team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
 }

--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -111,11 +111,6 @@ resource "github_repository_collaborators" "gebruikersonderzoeken" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "maintain"
     team_id    = github_team.gebruikersonderzoeken.id
   }

--- a/icons.tf
+++ b/icons.tf
@@ -109,11 +109,6 @@ resource "github_repository_collaborators" "icons" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.icons-committer.id
   }

--- a/index.tf
+++ b/index.tf
@@ -100,9 +100,4 @@ resource "github_repository_collaborators" "index" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
-
-  team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
 }

--- a/lux.tf
+++ b/lux.tf
@@ -143,11 +143,6 @@ resource "github_repository_collaborators" "lux" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.logius-committer.id
   }

--- a/matomo.tf
+++ b/matomo.tf
@@ -86,9 +86,4 @@ resource "github_repository_collaborators" "matomo" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
-
-  team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
 }

--- a/mendix.tf
+++ b/mendix.tf
@@ -115,11 +115,6 @@ resource "github_repository_collaborators" "mendix" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.gemeente-rotterdam-committer.id
   }

--- a/nldesignsystem-nl-storybook.tf
+++ b/nldesignsystem-nl-storybook.tf
@@ -141,9 +141,4 @@ resource "github_repository_collaborators" "kernteam-admin" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
-
-  team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
 }

--- a/nlds-community-blocks.tf
+++ b/nlds-community-blocks.tf
@@ -107,11 +107,6 @@ resource "github_repository_collaborators" "nlds-community-blocks" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.denhaag-draad.id
   }

--- a/nlds-gravity-forms.tf
+++ b/nlds-gravity-forms.tf
@@ -113,11 +113,6 @@ resource "github_repository_collaborators" "nlds-gravity-forms" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.gravityforms.id
   }

--- a/overheidsbrede-portalen-community.tf
+++ b/overheidsbrede-portalen-community.tf
@@ -109,11 +109,6 @@ resource "github_repository_collaborators" "overheidsbrede-portalen-community" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.vng-services-committer.id
   }

--- a/publiccode-parser-action.tf
+++ b/publiccode-parser-action.tf
@@ -77,9 +77,4 @@ resource "github_repository_collaborators" "publiccode-parser-action" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
-
-  team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
 }

--- a/rijkshuisstijl-community.tf
+++ b/rijkshuisstijl-community.tf
@@ -142,11 +142,6 @@ resource "github_repository_collaborators" "rijkshuisstijl-community" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.frameless.id
   }

--- a/rotterdam.tf
+++ b/rotterdam.tf
@@ -144,11 +144,6 @@ resource "github_repository_collaborators" "rotterdam" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "maintain"
     team_id    = github_team.gemeente-rotterdam-maintainer.id
   }

--- a/rvo.tf
+++ b/rvo.tf
@@ -139,11 +139,6 @@ resource "github_repository_collaborators" "rvo" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.rvo-committer.id
   }

--- a/team-members.tf
+++ b/team-members.tf
@@ -177,20 +177,6 @@ resource "github_team_members" "kernteam-ci" {
   }
 }
 
-resource "github_team_members" "kernteam-dependabot" {
-  team_id = github_team.kernteam-dependabot.id
-
-  members {
-    username = data.github_user.Robbert.username
-    # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
-    role = "maintainer"
-  }
-
-  members {
-    username = data.github_user.matijs.username
-  }
-}
-
 resource "github_team_members" "kernteam-a11y" {
   team_id = github_team.kernteam-a11y.id
 

--- a/team.tf
+++ b/team.tf
@@ -33,13 +33,6 @@ resource "github_team" "kernteam-ci" {
   privacy        = "closed"
 }
 
-resource "github_team" "kernteam-dependabot" {
-  name           = "kernteam-dependabot"
-  description    = "Default reviewers for Dependabot pull requests"
-  parent_team_id = github_team.kernteam.id
-  privacy        = "closed"
-}
-
 resource "github_team" "kernteam-maintainer" {
   name           = "kernteam-maintainer"
   description    = "Can configure GitHub via Terraform, with approval from kernteam-admin."

--- a/terraform.tf
+++ b/terraform.tf
@@ -89,11 +89,6 @@ resource "github_repository_collaborators" "terraform" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.kernteam-maintainer.id
   }

--- a/theme-builder.tf
+++ b/theme-builder.tf
@@ -91,11 +91,6 @@ resource "github_repository_collaborators" "theme-builder" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.expertteam-digitale-toegankelijkheid-committer.id
   }

--- a/themes.tf
+++ b/themes.tf
@@ -113,11 +113,6 @@ resource "github_repository_collaborators" "themes" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.gemeente-amsterdam.id
   }

--- a/tilburg.tf
+++ b/tilburg.tf
@@ -115,11 +115,6 @@ resource "github_repository_collaborators" "tilburg" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.tilburg-committer.id
   }

--- a/tiptap.tf
+++ b/tiptap.tf
@@ -130,11 +130,6 @@ resource "github_repository_collaborators" "tiptap" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.tiptap-committer.id
   }

--- a/utrecht.tf
+++ b/utrecht.tf
@@ -125,11 +125,6 @@ resource "github_repository_collaborators" "utrecht" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "maintain"
     team_id    = github_team.gemeente-utrecht.id
   }

--- a/wcag-statistieken.tf
+++ b/wcag-statistieken.tf
@@ -97,11 +97,6 @@ resource "github_repository_collaborators" "wcag-statistieken" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.expertteam-digitale-toegankelijkheid-committer.id
   }


### PR DESCRIPTION
Remove the `@nl-design-system/kernteam-dependabot team.

See [this GitHub blogpost][1] for more information. We're adding `.github/CODEOWNERS` to all repos that still lack them to keep functional parity.

[1]: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/