### PR TITLE
Set root directory for gebruikersonderzoeken-next

### DIFF
--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -139,8 +139,9 @@ resource "vercel_project" "gebruikersonderzoeken" {
 
 resource "vercel_project" "gebruikersonderzoeken-next" {
   name             = "gebruikersonderzoeken-next"
-  output_directory = "packages/website/dist/"
-  build_command    = "pnpm run build:astro"
+  output_directory = "dist/"
+  build_command    = "pnpm run build"
+  root_directory   = "packages/website/"
   ignore_command   = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
   node_version     = "22.x"
 


### PR DESCRIPTION
Om een vercel.json file te kunnen gebruiken in packages/website/ in de gebruikersonderzoeken repo, de vercel project root moet gezet zijn, anders wordt er alleen gekeken naar de vercel.json file in de root van de repo en niet dieper
