### PR TITLE
fix: gebruikersonderzoeken

### DIFF
--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -138,12 +138,13 @@ resource "vercel_project" "gebruikersonderzoeken" {
 }
 
 resource "vercel_project" "gebruikersonderzoeken-next" {
-  name             = "gebruikersonderzoeken-next"
-  output_directory = "dist/"
-  build_command    = "pnpm run build"
-  root_directory   = "packages/website/"
-  ignore_command   = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
-  node_version     = "22.x"
+  name                                 = "gebruikersonderzoeken-next"
+  output_directory                     = "dist/"
+  build_command                        = "pnpm run build"
+  enable_affected_projects_deployments = false
+  root_directory                       = "packages/website/"
+  ignore_command                       = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
+  node_version                         = "22.x"
 
   git_repository = {
     type = "github"


### PR DESCRIPTION
Explicitly set `enable_affected_projects_deployments` to `false` as a workaround for what seems like a bug [1] in the provider.

[1]: https://github.com/vercel/terraform-provider-vercel/issues/296