### PR TITLE
chore: add discussions to gebruikersonderzoeken

### DIFF
--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -10,6 +10,7 @@ resource "github_repository" "gebruikersonderzoeken" {
   has_downloads               = false
   has_projects                = true
   has_wiki                    = false
+  has_discussions             = true
   vulnerability_alerts        = true
   homepage_url                = "https://gebruikersonderzoeken.nl/"
   squash_merge_commit_title   = "PR_TITLE"


### PR DESCRIPTION
Voor de pilot van CIDO willen we graag dat mensen feedback geven via een GitHub Discussion. Deze is niet logisch bij de backlog, maar juist wel bij gebruikersonderzoeken.