### PR TITLE
ci: allow anchore/sbom-action in GitHub Actions

### DIFF
--- a/github_organization.tf
+++ b/github_organization.tf
@@ -20,6 +20,7 @@ resource "github_actions_organization_permissions" "nl-design-system" {
       "actions/upload-artifact@*",
       "actions/upload-pages-artifact@*",
       # Third party organisation owned actions
+      "anchore/sbom-action@*",
       "changesets/action@*",
       "chromaui/action@*",
       "codecov/codecov-action@*",


### PR DESCRIPTION
Nodig voor https://github.com/nl-design-system/utrecht/pull/2875 voor de SBoM die in de ICTU Kwaliteitsaanpak staat.