### PR TITLE
chore: add utrecht committer and maintainer teams and add pixelgitter user

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,25 +65,30 @@ Removing this code should allow you to switch back to storing state in `terrafor
 - provider: [`vercel`](https://registry.terraform.io/providers/vercel/vercel/latest/docs)
   - resource: [`vercel_project`](https://registry.terraform.io/providers/vercel/vercel/latest/docs/resources/project)
 
-## Permission Structure
+## Permission structure
+
 Most communities within the NL Design System use a standard structure for their permissions and teams.
 
 ### Teams
-An organisation (or repository) has three teams: Triage, Committer, Maintainer
+
+An organisation (or repository) usually has three teams: Triage, Committer, Maintainer
 - `organisation-triage`
 - `organisation-committer`
 - `organisation-maintainer`
 
 ### Triage permissions
+
 - Can create issues
 - Can label issues
 
 ### Committer permissions
+
 - All triage permissions
 - Can push to repository
 - Can merge pull requests (if conditions such as approvals are met)
 
 ### Maintainer permissions
+
 - All committer permissions
 - Add users (**⚠️ Note**: do not use this permission, always modify users through terraform)
 - Review pull requests

--- a/README.md
+++ b/README.md
@@ -65,6 +65,31 @@ Removing this code should allow you to switch back to storing state in `terrafor
 - provider: [`vercel`](https://registry.terraform.io/providers/vercel/vercel/latest/docs)
   - resource: [`vercel_project`](https://registry.terraform.io/providers/vercel/vercel/latest/docs/resources/project)
 
+## Permission Structure
+Most communities within the NL Design System use a standard structure for their permissions and teams.
+
+### Teams
+An organisation (or repository) has three teams: Triage, Committer, Maintainer
+- `organisation-triage`
+- `organisation-committer`
+- `organisation-maintainer`
+
+### Triage permissions
+- Can create issues
+- Can label issues
+
+### Committer permissions
+- All triage permissions
+- Can push to repository
+- Can merge pull requests (if conditions such as approvals are met)
+
+### Maintainer permissions
+- All committer permissions
+- Add users (**⚠️ Note**: do not use this permission, always modify users through terraform)
+- Review pull requests
+- Work with the NL Design System Kernteam to add new members
+- Create Github Milestones and modify labels
+
 ## Contributing: new GitHub user to existing team
 
 1. Add the `github_user` to [`user.tf`](./user.tf).

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Most communities within the NL Design System use a standard structure for their 
 
 ### Teams
 
-An organisation (or repository) usually has three teams: Triage, Committer, Maintainer
+An organisation (or repository) usually has three teams: Triage, Committer, Maintainer ([also see the Github Documentation on permissions](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role))
+
 - `organisation-triage`
 - `organisation-committer`
 - `organisation-maintainer`

--- a/team-members.tf
+++ b/team-members.tf
@@ -542,6 +542,26 @@ resource "github_team_members" "rvo-estafettemodel" {
   }
 }
 
+resource "github_team_members" "gemeente-utrecht-committer" {
+  team_id = github_team.gemeente-utrecht-committer.id
+}
+
+resource "github_team_members" "gemeente-utrecht-maintainer" {
+  team_id = github_team.gemeente-utrecht-maintainer.id
+
+  members {
+    username = data.github_user.JeroenduC.username
+  }
+
+  members {
+    username = data.github_user.Ollie-nl.username
+  }
+
+  members {
+    username = data.github_user.pixelgitter.username
+  }
+}
+
 resource "github_team_members" "gemeente-utrecht-estafettemodel" {
   team_id = github_team.gemeente-utrecht-estafettemodel.id
 
@@ -876,10 +896,6 @@ resource "github_team_members" "community-committer" {
 
   members {
     username = data.github_user.dineshduggal.username
-  }
-
-  members {
-    username = data.github_user.pixelgitter.username
   }
 
   # Den Haag folks

--- a/team-members.tf
+++ b/team-members.tf
@@ -878,6 +878,10 @@ resource "github_team_members" "community-committer" {
     username = data.github_user.dineshduggal.username
   }
 
+  members {
+    username = data.github_user.pixelgitter.username
+  }
+
   # Den Haag folks
   members {
     username = data.github_user.jiromaykin.username

--- a/team-members.tf
+++ b/team-members.tf
@@ -542,10 +542,6 @@ resource "github_team_members" "rvo-estafettemodel" {
   }
 }
 
-resource "github_team_members" "gemeente-utrecht-committer" {
-  team_id = github_team.gemeente-utrecht-committer.id
-}
-
 resource "github_team_members" "gemeente-utrecht-maintainer" {
   team_id = github_team.gemeente-utrecht-maintainer.id
 

--- a/team.tf
+++ b/team.tf
@@ -147,9 +147,16 @@ resource "github_team" "gemeente-utrecht" {
   privacy     = "closed"
 }
 
+resource "github_team" "gemeente-utrecht-triage" {
+  name           = "gemeente-utrecht-triage"
+  parent_team_id = github_team.gemeente-utrecht.id
+  description    = "Gemeente Utrecht (Triage)"
+  privacy        = "closed"
+}
+
 resource "github_team" "gemeente-utrecht-committer" {
   name           = "gemeente-utrecht-committer"
-  parent_team_id = github_team.gemeente-utrecht.id
+  parent_team_id = github_team.gemeente-utrecht-triage.id
   description    = "Gemeente Utrecht (Committer)"
   privacy        = "closed"
 }

--- a/team.tf
+++ b/team.tf
@@ -147,6 +147,20 @@ resource "github_team" "gemeente-utrecht" {
   privacy     = "closed"
 }
 
+resource "github_team" "gemeente-utrecht-committer" {
+  name           = "gemeente-utrecht-committer"
+  parent_team_id = github_team.gemeente-utrecht.id
+  description    = "Gemeente Utrecht (Committer)"
+  privacy        = "closed"
+}
+
+resource "github_team" "gemeente-utrecht-maintainer" {
+  name           = "gemeente-utrecht-maintainer"
+  parent_team_id = github_team.gemeente-utrecht-committer.id
+  description    = "Gemeente Utrecht (Maintainer)"
+  privacy        = "closed"
+}
+
 resource "github_team" "gemeente-utrecht-estafettemodel" {
   name           = "gemeente-utrecht-estafettemodel"
   parent_team_id = github_team.gemeente-utrecht.id

--- a/user.tf
+++ b/user.tf
@@ -481,3 +481,7 @@ data "github_user" "veslav3" {
 data "github_user" "jiromaykin" {
   username = "jiromaykin"
 }
+
+data "github_user" "pixelgitter" {
+  username = "pixelgitter"
+}

--- a/utrecht.tf
+++ b/utrecht.tf
@@ -115,6 +115,21 @@ resource "github_repository_collaborators" "utrecht" {
   }
 
   team {
+    permission = "maintain"
+    team_id = github_team.gemeente-utrecht-maintainer.id
+  }
+
+  team {
+    permission = "push"
+    team_id = github_team.gemeente-utrecht-committer.id
+  }
+
+  team {
+    permission = "triage"
+    team_id = github_team.gemeente-utrecht-triage.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.kernteam-committer.id
   }

--- a/utrecht.tf
+++ b/utrecht.tf
@@ -116,17 +116,17 @@ resource "github_repository_collaborators" "utrecht" {
 
   team {
     permission = "maintain"
-    team_id = github_team.gemeente-utrecht-maintainer.id
+    team_id    = github_team.gemeente-utrecht-maintainer.id
   }
 
   team {
     permission = "push"
-    team_id = github_team.gemeente-utrecht-committer.id
+    team_id    = github_team.gemeente-utrecht-committer.id
   }
 
   team {
     permission = "triage"
-    team_id = github_team.gemeente-utrecht-triage.id
+    team_id    = github_team.gemeente-utrecht-triage.id
   }
 
   team {


### PR DESCRIPTION
Op verzoek van Utrecht kernteam, toevoegen van nieuw team lid om te kunnen pushen naar een branch. Voor consistentie ook ontbrekende utrecht teams aangemaakt (maintainer, committer, triage)

Daarnaast op verzoek van zowel Utrecht kernteam als @Robbert documentatie toegevoegd aan `README.md` over de structuur van permissions.