### PR TITLE
docs: add missing code of conduct files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,118 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement via
+[kernteam@nldesignsystem.nl](mailto:kernteam@nldesignsystem.nl)
+or by contacting [the team](https://nldesignsystem.nl/project/kernteam) on Slack.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).

--- a/CODE_OF_CONDUCT.nl.md
+++ b/CODE_OF_CONDUCT.nl.md
@@ -1,0 +1,87 @@
+# Contributor Covenant Gedragscode (Code of Conduct)
+
+## Onze belofte
+
+Wij als leden, contribuanten en communityleiders beloven om deelname aan onze community een intimidatievrije ervaring te maken voor iedereen, ongeacht leeftijd, lichaamsbouw, zichtbare of onzichtbare handicap, etniciteit, geslachtskenmerken, genderidentiteit en -expressie, ervaringsniveau, opleiding, sociaal-economische status, nationaliteit, voorkomen, ras, religie of seksuele identiteit en -oriëntatie.
+
+We beloven om te handelen en te communiceren op een manier die bijdraagt aan een open, gastvrije, diverse, inclusieve en gezonde community.
+
+## Onze standaarden
+
+Voorbeelden van gedrag dat bijdraagt aan een positieve omgeving voor onze community:
+
+- Empathie en vriendelijkheid tonen tegenover andere mensen
+- Verschillende meningen, standpunten en ervaringen respecteren
+- Constructieve feedback geven en gracieus accepteren
+- Verantwoordelijkheid aanvaarden en excuses aanbieden aan degenen die door onze fouten zijn getroffen,
+  en leren van de ervaring
+- Focussen op wat het beste is voor de algemene gemeenschap, niet alleen voor ons als individuen
+
+Voorbeelden van onaanvaardbaar gedrag zijn:
+
+- Het gebruik van geseksualiseerde taal of beelden en seksuele aandacht of toenadering van welke aard dan ook
+- "Trollen", beledigende of denigrerende opmerkingen en persoonlijke- of politieke aanvallen
+- Openbare- of privé-intimidatie
+- Publiceren van persoonlijke informatie van anderen, zoals een fysiek adres of e-mail adres, zonder hun uitdrukkelijke toestemming
+- Ander gedrag dat redelijkerwijs als ongepast zou kunnen worden beschouwd in een professionele setting
+
+## Verantwoordelijkheden bij handhaving
+
+Communityleiders zijn verantwoordelijk voor het verduidelijken en handhaven van onze normen van acceptabel gedrag en zullen passende en eerlijke corrigerende maatregelen nemen in reactie op elk gedrag dat zij ongepast, bedreigend, aanstootgevend, of schadelijk vinden.
+
+Communityleiders hebben het recht en de verantwoordelijkheid om opmerkingen, commits, code, wiki-bewerkingen, issues en andere bijdragen die niet in overeenstemming met deze Gedragscode zijn te verwijderen, bewerken of afwijzen en zullen redenen voor moderatie meedelen waar nodig.
+
+## Toepassingsgebied
+
+Deze Gedragscode is van toepassing binnen alle gemeenschappelijke ruimtes en is ook van toepassing wanneer een individu officieel de community in openbare ruimtes vertegenwoordigt.
+Voorbeelden van het vertegenwoordigen van onze community zijn onder meer het gebruik van een officieel e-mailadres, berichten plaatsen via een officieel social media account of optreden als een aangestelde vertegenwoordiger bij een online of offline evenement.
+
+## Handhaving
+
+Beledigend, intimiderend of anderszins onaanvaardbaar gedrag kan gerapporteerd worden aan de communityleiders die verantwoordelijk zijn voor handhaving via [kernteam@nldesignsystem.nl](mailto:kernteam@nldesignsystem.nl) of door rechtstreeks contact op te nemen met [leden van het kernteam](https://nldesignsystem.nl/project/kernteam) (via Slack of email).
+Alle klachten zullen onmiddellijk en eerlijk worden beoordeeld en onderzocht.
+
+Alle communityleiders zijn verplicht om de privacy en veiligheid van de melder van een incident te respecteren.
+
+## Handhavingsrichtlijnen
+
+Communityleiders zullen onderstaande "Community Impact Guidelines" volgen bij het bepalen van de consequenties van elke handeling die zij in strijd met de Gedragscode achten:
+
+### 1. Correctie
+
+**Impact op de community**: Gebruik van ongepast taalgebruik en ander gedrag dat onprofessioneel of als niet gewenst wordt geacht in de community.
+
+**Consequentie**: Een persoonlijke, schriftelijke waarschuwing van communityleiders, verduidelijking over de aard van de overtreding en een uitleg waarom het gedrag ongepast wordt geacht. Mogelijk wordt hierbij om een openbare verontschuldiging gevraagd.
+
+### 2. Waarschuwing
+
+**Impact op de community**: Een overtreding door een enkel incident of reeks van acties.
+
+**Consequentie**: Een waarschuwing met gevolgen als het gedrag voortduurt. Geen interactie met de betrokken personen, inclusief ongevraagde interactie met degenen die de Gedragscode handhaven, voor een bepaalde periode. Dit omvat het vermijden van interacties in gemeenschappelijke ruimtes en externe kanalen zoals op social media. Het overtreden van deze voorwaarden kan leiden tot een tijdelijke of permanente ban.
+
+### 3. Tijdelijk verbod
+
+**Impact op de community**: Een ernstige schending van community normen, inclusief aanhoudend ongepast gedrag.
+
+**Consequentie**: Een tijdelijk verbod op elke vorm van interactie of openbare communicatie met de community gedurende een bepaalde periode. Geen publieke- of privé-interactie met de betrokken personen, inclusief ongevraagde interactie met degenen die de Gedragscode handhaven, is toegestaan tijdens deze periode.
+Het overtreden van deze voorwaarden kan leiden tot een permanente ban.
+
+### 4. Permanente ban
+
+**Impact op de community**: Een patroon van schending van de community standaarden vertonen, waaronder aanhoudend ongepast gedrag, intimidatie van een individu of agressie jegens- of kleinering van groepen van individuen.
+
+**Consequentie**: Een permanent verbod op elke vorm van openbare interactie in de community.
+
+## Attributie
+
+Deze gedragscode is een aangepaste versie van de [Contributor Covenant][homepage], versie 2.0, beschikbaar op [https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+Richtlijnen voor impact op de community zijn geïnspireerd door [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+Voor antwoorden op veelgestelde vragen over deze gedragscode, zie de veelgestelde vragen op [https://www.contributor-covenant.org/faq][FAQ]. Er zijn vertalingen beschikbaar op [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
Make the Code of Conduct for this repository explicit in the repository instead of relying on the Code of Conduct that lives in https://github.com/nl-design-system/.github