### PR TITLE
chore: expertteam tweaks

### DIFF
--- a/editor.tf
+++ b/editor.tf
@@ -119,6 +119,11 @@ resource "github_repository_collaborators" "editor" {
   }
 
   team {
+    permission = "maintain"
+    team_id    = github_team.expertteam-digitale-toegankelijkheid-maintainer.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.expertteam-digitale-toegankelijkheid-committer.id
   }

--- a/team-members.tf
+++ b/team-members.tf
@@ -905,14 +905,6 @@ resource "github_team_members" "expertteam-digitale-toegankelijkheid-triage" {
   team_id = github_team.expertteam-digitale-toegankelijkheid-triage.id
 
   members {
-    username = data.github_user.RenateRoke.username
-  }
-
-  members {
-    username = data.github_user.Rozerinay.username
-  }
-
-  members {
     # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
     username = data.github_user.Robbert.username
     role     = "maintainer"
@@ -974,6 +966,30 @@ resource "github_team_members" "expertteam-digitale-toegankelijkheid-committer" 
 
   members {
     username = data.github_user.ermenm.username
+  }
+}
+
+resource "github_team_members" "expertteam-digitale-toegankelijkheid-maintainer" {
+  team_id = github_team.expertteam-digitale-toegankelijkheid-maintainer.id
+
+  members {
+    # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
+    username = data.github_user.Robbert.username
+    role     = "maintainer"
+  }
+
+  members {
+    # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
+    username = data.github_user.Yolijn.username
+    role     = "maintainer"
+  }
+
+  members {
+    username = data.github_user.pibl.username
+  }
+
+  members {
+    username = data.github_user.huijkman.username
   }
 }
 

--- a/team.tf
+++ b/team.tf
@@ -645,6 +645,13 @@ resource "github_team" "expertteam-digitale-toegankelijkheid-committer" {
   description    = "Committers of the Expert Team for Digital Accessibility"
 }
 
+resource "github_team" "expertteam-digitale-toegankelijkheid-maintainer" {
+  name           = "expertteam-digitale-toegankelijkheid-maintainer"
+  parent_team_id = github_team.expertteam-digitale-toegankelijkheid-committer.id
+  privacy        = "closed"
+  description    = "Maintainers of the Expert Team for Digital Accessibility"
+}
+
 resource "github_team" "developer_overheid_nl-committer" {
   name        = "developer_overheid_nl-committer"
   privacy     = "closed"

--- a/theme-builder.tf
+++ b/theme-builder.tf
@@ -26,7 +26,7 @@ resource "github_repository" "theme-builder" {
   }
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 }
 

--- a/theme-wizard.tf
+++ b/theme-wizard.tf
@@ -150,3 +150,20 @@ resource "vercel_project" "theme-wizard" {
     deployment_type = "none"
   }
 }
+
+resource "vercel_project" "theme-wizard-storybook" {
+  name             = "theme-wizard-storybook"
+  output_directory = "packages/storybook/dist/"
+  build_command    = "pnpm run build"
+  ignore_command   = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
+  node_version     = "22.x"
+
+  git_repository = {
+    type = "github"
+    repo = github_repository.theme-wizard.full_name
+  }
+
+  vercel_authentication = {
+    deployment_type = "none"
+  }
+}

--- a/theme-wizard.tf
+++ b/theme-wizard.tf
@@ -119,6 +119,11 @@ resource "github_repository_collaborators" "theme-wizard" {
   }
 
   team {
+    permission = "maintain"
+    team_id    = github_team.expertteam-digitale-toegankelijkheid-maintainer.id
+  }
+
+  team {
     permission = "push"
     team_id    = github_team.expertteam-digitale-toegankelijkheid-committer.id
   }


### PR DESCRIPTION
Doel:
- maintainer team toevoegen voor expertteam voor maintainer rechten in GitHub, zodat deze mensen Project boards kunnen aanpassen en GitHub Milestones en Labels kunnen bewerken
- blijkbaar was er al een theme-builder repo, die kan weg nu we theme-wizard hebben
- de teamsamenstelling was anders eerder dit jaar, alleen de huidige teamleden hoeven rechten te hebben. De verwijderde mensen hebben alsnog veel rechten doordat ze in het kernteam zitten.
- Extra branch deploy omdat er meerdere dingen in theme-wizard zitten: de website en storybook