### PR TITLE
chore: enable GitHub Pages for icons repo

### DIFF
--- a/icons.tf
+++ b/icons.tf
@@ -16,6 +16,16 @@ resource "github_repository" "icons" {
   squash_merge_commit_message = "PR_BODY"
   topics                      = ["nl-design-system", "icons"]
 
+  pages {
+    build_type = "workflow"
+
+    # A `source` block is only needed when `build_type` is set to `"legacy"`, but because GitHub keeps it around invisibly, we must add it here to prevent churn
+    source {
+      branch = "main"
+      path   = "/"
+    }
+  }
+
   template {
     include_all_branches = false
     owner                = "nl-design-system"


### PR DESCRIPTION
I'm running into an issue in the icons repo where it cannot get the Pages configuration: https://github.com/nl-design-system/icons/actions/runs/18568012962

I have two options: disable the workflow, or enable the configuration.  Since it seems like the Pages should be there, and to keep the workflow file as close to the example as possible, I opted to enable it.