### PR TITLE
chore: remove romy

### DIFF
--- a/team-members.tf
+++ b/team-members.tf
@@ -317,10 +317,6 @@ resource "github_team_members" "logius-committer" {
   }
 
   members {
-    username = data.github_user.romy-petitjean-logius.username
-  }
-
-  members {
     username = data.github_user.rnacken.username
   }
 

--- a/user.tf
+++ b/user.tf
@@ -550,10 +550,6 @@ data "github_user" "SabineMeijerNuboer" {
   username = "SabineMeijerNuboer"
 }
 
-data "github_user" "romy-petitjean-logius" {
-  username = "romy-petitjean-logius"
-}
-
 data "github_user" "gzeilstra" {
   username = "gzeilstra"
 }


### PR DESCRIPTION
Voorheen toegevoegd en approved in https://github.com/nl-design-system/terraform/pull/498.
Nu verwijderd, en straks opnieuw toegevoegd in nieuwe PR, omdat haar uitnodiging lijkt expired te zijn.