### PR TITLE
ci: allow CodeQL GitHub Action

### DIFF
--- a/github_organization.tf
+++ b/github_organization.tf
@@ -19,6 +19,7 @@ resource "github_actions_organization_permissions" "nl-design-system" {
       "actions/setup-node@*",
       "actions/upload-artifact@*",
       "actions/upload-pages-artifact@*",
+      "github/codeql-action@*",
       # Third party organisation owned actions
       "anchore/sbom-action@*",
       "changesets/action@*",


### PR DESCRIPTION
Hopefully is allowing this one action, in combination with our existing list of allowed `action/`-prefixed actions, enough to allow GitHub code scanning. If not, we can consider adding `action/*`.
<img width="797" height="212" alt="Screenshot 2025-11-21 at 14 26 50" src="https://github.com/user-attachments/assets/14529ebf-a51d-4409-a86b-631faa61512e" />


