### PR TITLE
chore: allow all GitHub maintained actions

### DIFF
--- a/github_organization.tf
+++ b/github_organization.tf
@@ -10,15 +10,7 @@ resource "github_actions_organization_permissions" "nl-design-system" {
     github_owned_allowed = true
     patterns_allowed = [
       # GitHub owned actions
-      "actions/cache@*",
-      "actions/checkout@*",
-      "actions/configure-pages@*",
-      "actions/create-github-app-token@*",
-      "actions/deploy-pages@*",
-      "actions/download-artifact@*",
-      "actions/setup-node@*",
-      "actions/upload-artifact@*",
-      "actions/upload-pages-artifact@*",
+      "actions/*",
       "github/codeql-action@*",
       # Third party organisation owned actions
       "anchore/sbom-action@*",


### PR DESCRIPTION
De beperkte change uit #513 werkte helaas niet:

<img width="789" height="459" alt="Screenshot 2025-11-21 at 16 38 21" src="https://github.com/user-attachments/assets/87d3a252-44e5-43ac-ab55-36a67f381add" />
