### PR TITLE
feat: add discussions for lux

### DIFF
--- a/lux.tf
+++ b/lux.tf
@@ -6,6 +6,7 @@ resource "github_repository" "lux" {
   allow_squash_merge          = true
   allow_auto_merge            = true
   delete_branch_on_merge      = true
+  has_discussions             = true
   has_issues                  = true
   has_downloads               = false
   has_projects                = true


### PR DESCRIPTION
Per request van Aline. Alvast in Lux in de repo op Get started geklikt in de Discussions tab, zodat deze bestaat. Nu in terraform zodat ie ook echt blijft staan. Vandaar dat ie geen changes aangeeft?

Onderdeel van https://github.com/nl-design-system/kernteam/issues/1619