### PR TITLE
ci: add new "issues" environment for less sensitive tokens

### DIFF
--- a/editor.tf
+++ b/editor.tf
@@ -166,6 +166,12 @@ resource "github_repository_environment" "editor-publish" {
   }
 }
 
+resource "github_repository_environment" "editor-issues" {
+  # Environment for GitHub Actions triggered by issues
+  environment = "Issues"
+  repository  = github_repository.editor.name
+}
+
 resource "github_repository_deployment_branch_policy" "editor-publish-main" {
   depends_on = [github_repository_environment.editor-publish]
 

--- a/theme-wizard.tf
+++ b/theme-wizard.tf
@@ -136,6 +136,12 @@ resource "github_repository_environment" "theme-wizard-publish" {
   }
 }
 
+resource "github_repository_environment" "theme-wizard-issues" {
+  # Environment for GitHub Actions triggered by issues
+  environment = "Issues"
+  repository  = github_repository.theme-wizard.name
+}
+
 resource "github_repository_deployment_branch_policy" "theme-wizard-publish-main" {
   depends_on = [github_repository_environment.theme-wizard-publish]
 


### PR DESCRIPTION
Related PR:
https://github.com/nl-design-system/theme-wizard/pull/257

Ik wil een environment waar ik die personal access token voor [actions/add-to-project](https://github.com/actions/add-to-project) kan instellen