### PR TITLE
Disable vercel preview comments/toolbar on theme-wizard

### DIFF
--- a/theme-wizard.tf
+++ b/theme-wizard.tf
@@ -145,11 +145,11 @@ resource "github_repository_deployment_branch_policy" "theme-wizard-publish-main
 }
 
 resource "vercel_project" "theme-wizard" {
-  name             = "theme-wizard"
-  ignore_command   = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
-  node_version     = "22.x"
-  root_directory   = "packages/theme-wizard-website/"
-  preview_comments = false
+  name                    = "theme-wizard"
+  ignore_command          = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
+  node_version            = "22.x"
+  root_directory          = "packages/theme-wizard-website/"
+  enable_preview_feedback = false
 
 
   git_repository = {


### PR DESCRIPTION
Deze feature gebruiken we niet en zonder de extra JS bundles is het ook makkelijker om performance audits te doen voor de wizard (die we nodig gaan hebben op niet al te lange termijn).

https://registry.terraform.io/providers/vercel/vercel/latest/docs/resources/project#enable_preview_feedback-1