### PR TITLE
chore: add richadr to kernteam-maintainer

### DIFF
--- a/team-members.tf
+++ b/team-members.tf
@@ -125,6 +125,10 @@ resource "github_team_members" "kernteam-maintainer" {
   members {
     username = data.github_user.veslav3.username
   }
+
+  members {
+    username = data.github_user.richadr.username
+  }
 }
 
 resource "github_team_members" "kernteam-triage" {


### PR DESCRIPTION
Some repos require this role for reviewing
