### PR TITLE
feat: allow slack github action

### DIFF
--- a/github_organization.tf
+++ b/github_organization.tf
@@ -20,6 +20,7 @@ resource "github_actions_organization_permissions" "nl-design-system" {
       "hashicorp/setup-terraform@*",
       "php-actions/composer@*",
       "pnpm/action-setup@*",
+      "slackapi/slack-github-action@*",
       # Third party individually owned actions
       "amannn/action-semantic-pull-request@*",
       "JamesIves/github-pages-deploy-action@*",


### PR DESCRIPTION
Allow the use of Slack's own Github action for posting to channels when pipelines fail.