### PR TITLE
feat: add hosting infra repo and team

### DIFF
--- a/hosting.tf
+++ b/hosting.tf
@@ -1,0 +1,127 @@
+resource "github_repository" "hosting" {
+  name                        = "hosting"
+  description                 = "Infrastructure as code: we configure cloud hosting via OpenTofu configuration files"
+  allow_merge_commit          = false
+  allow_rebase_merge          = true
+  allow_squash_merge          = true
+  allow_auto_merge            = false
+  delete_branch_on_merge      = true
+  has_issues                  = true
+  has_downloads               = false
+  has_projects                = false
+  has_wiki                    = false
+  has_discussions             = false
+  vulnerability_alerts        = true
+  visibility                  = "public"
+  squash_merge_commit_title   = "PR_TITLE"
+  squash_merge_commit_message = "PR_BODY"
+
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_branch_default" "hosting-branch-default" {
+  repository = github_repository.hosting.name
+  branch     = "main"
+}
+
+resource "github_repository_ruleset" "hosting-main" {
+  enforcement = "active"
+  name        = "default-branch-protection"
+  repository  = github_repository.hosting.name
+  target      = "branch"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                      = false
+    deletion                      = true
+    non_fast_forward              = true
+    required_linear_history       = true
+    required_signatures           = false
+    update                        = false
+    update_allows_fetch_and_merge = false
+
+    pull_request {
+      dismiss_stale_reviews_on_push     = true
+      require_code_owner_review         = true
+      require_last_push_approval        = false
+      required_approving_review_count   = 2
+      required_review_thread_resolution = true
+    }
+  }
+}
+
+resource "github_repository_collaborators" "hosting" {
+  repository = github_repository.hosting.name
+
+  # Restrict merging PRs to admins via /.github/CODEOWNERS
+
+  team {
+    permission = "admin"
+    team_id    = github_team.kernteam-admin.id
+  }
+
+  team {
+    permission = "triage"
+    team_id    = github_team.kernteam-dependabot.id
+  }
+
+  team {
+    permission = "push"
+    team_id    = github_team.kernteam-maintainer.id
+  }
+
+  # Expertteam is the main stakeholder for hosting, initially
+  team {
+    permission = "push"
+    team_id    = github_team.expertteam-digitale-toegankelijkheid-infra.id
+  }
+
+  team {
+    # Allow the entire Expertteam to make PRs to propose changes, others can review.
+    permission = "push"
+    team_id    = github_team.expertteam-digitale-toegankelijkheid-committer.id
+  }
+
+  # Restrict pushes to infrastructure as code to admins and maintainers
+
+  team {
+    permission = "triage"
+    team_id    = github_team.expertteam-digitale-toegankelijkheid-triage.id
+  }
+}
+
+resource "github_repository_environment" "hosting-publish" {
+  environment       = "Publish"
+  repository        = github_repository.hosting.name
+  can_admins_bypass = false
+
+  deployment_branch_policy {
+    protected_branches     = false
+    custom_branch_policies = true
+  }
+}
+
+resource "github_repository_deployment_branch_policy" "hosting-publish-main" {
+  depends_on = [github_repository_environment.hosting-publish]
+
+  repository       = github_repository.hosting.name
+  environment_name = github_repository_environment.hosting-publish.environment
+  name             = github_branch_default.hosting-branch-default.branch
+}

--- a/team-members.tf
+++ b/team-members.tf
@@ -1074,6 +1074,22 @@ resource "github_team_members" "expertteam-digitale-toegankelijkheid-maintainer"
   }
 }
 
+resource "github_team_members" "expertteam-digitale-toegankelijkheid-infra" {
+  team_id = github_team.expertteam-digitale-toegankelijkheid-infra.id
+
+  members {
+    username = data.github_user.bartjkdp.username
+  }
+
+  members {
+    username = data.github_user.georgealpha9.username
+  }
+
+  members {
+    username = data.github_user.iehkaatee.username
+  }
+}
+
 resource "github_team_members" "developer_overheid_nl-committer" {
   team_id = github_team.developer_overheid_nl-committer.id
 

--- a/team.tf
+++ b/team.tf
@@ -652,6 +652,13 @@ resource "github_team" "expertteam-digitale-toegankelijkheid-maintainer" {
   description    = "Maintainers of the Expert Team for Digital Accessibility"
 }
 
+resource "github_team" "expertteam-digitale-toegankelijkheid-infra" {
+  name           = "expertteam-digitale-toegankelijkheid-infra"
+  parent_team_id = github_team.expertteam-digitale-toegankelijkheid.id
+  privacy        = "closed"
+  description    = "Infrastructure engineers of the Expert Team for Digital Accessibility"
+}
+
 resource "github_team" "developer_overheid_nl-committer" {
   name        = "developer_overheid_nl-committer"
   privacy     = "closed"

--- a/user.tf
+++ b/user.tf
@@ -569,3 +569,15 @@ data "github_user" "JuliaTol-properaccess" {
 data "github_user" "fKasteleinDictu" {
   username = "fKasteleinDictu"
 }
+
+data "github_user" "bartjkdp" {
+  username = "bartjkdp"
+}
+
+data "github_user" "georgealpha9" {
+  username = "georgealpha9"
+}
+
+data "github_user" "iehkaatee" {
+  username = "iehkaatee"
+}


### PR DESCRIPTION
Expertteam Digitale Toegankelijkheid krijgt cloud hosting, die we op een vergelijkbare manier willen beheren via Infrastructure as Code als deze terraform repository. Daarvoor gebruiken we echter een fork van Terraform: [OpenTofu](https://opentofu.org).

Er komen 3 users bij van [Delta10](https://www.delta10.nl) die de cloud hosting gaan regelen via OpenTofu.