### PR TITLE
feat: add BabsyBabs83 for logius

### DIFF
--- a/team-members.tf
+++ b/team-members.tf
@@ -343,6 +343,10 @@ resource "github_team_members" "logius-committer" {
   members {
     username = data.github_user.DorineLogius.username
   }
+
+  members {
+    username = data.github_user.BabsyBabs83.username
+  }
 }
 
 resource "github_team_members" "logius-maintainer" {
@@ -927,6 +931,10 @@ resource "github_team_members" "community-committer" {
 
   members {
     username = data.github_user.dineshduggal.username
+  }
+
+  members {
+    username = data.github_user.BabsyBabs83.username
   }
 
   # Den Haag folks

--- a/user.tf
+++ b/user.tf
@@ -585,3 +585,7 @@ data "github_user" "photosjob" {
 data "github_user" "DorineLogius" {
   username = "DorineLogius"
 }
+
+data "github_user" "BabsyBabs83" {
+  username = "BabsyBabs83"
+}


### PR DESCRIPTION
Requested by dineshduggal. Access to RHC, done via community-committer. Since it's team Logius, it needs approval from cascassette or FinnWard.