### PR TITLE
chore: remove kernteam-dependabot team

### DIFF
--- a/architectuur.tf
+++ b/architectuur.tf
@@ -120,11 +120,6 @@ resource "github_repository_collaborators" "architectuur" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.expertteam-digitale-toegankelijkheid-committer.id
   }

--- a/basis.tf
+++ b/basis.tf
@@ -122,11 +122,6 @@ resource "github_repository_collaborators" "basis" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.community-contributor.id
   }

--- a/candidate.tf
+++ b/candidate.tf
@@ -126,11 +126,6 @@ resource "github_repository_collaborators" "candidate" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.community-contributor.id
   }

--- a/denhaag.tf
+++ b/denhaag.tf
@@ -182,11 +182,6 @@ resource "github_repository_collaborators" "denhaag" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "admin"
     team_id    = github_team.gemeente-denhaag-admin.id
   }

--- a/documentatie.tf
+++ b/documentatie.tf
@@ -144,11 +144,6 @@ resource "github_repository_collaborators" "documentatie" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.community-contributor.id
   }

--- a/dot-github.tf
+++ b/dot-github.tf
@@ -84,9 +84,4 @@ resource "github_repository_collaborators" "dot-github" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
-
-  team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
 }

--- a/example-with-angular.tf
+++ b/example-with-angular.tf
@@ -114,11 +114,6 @@ resource "github_repository_collaborators" "example-with-angular" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.frameless.id
   }

--- a/example.tf
+++ b/example.tf
@@ -115,11 +115,6 @@ resource "github_repository_collaborators" "example" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.community-contributor.id
   }

--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -114,11 +114,6 @@ resource "github_repository_collaborators" "gebruikersonderzoeken" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "maintain"
     team_id    = github_team.gebruikersonderzoeken.id
   }

--- a/hall-of-fame.tf_
+++ b/hall-of-fame.tf_
@@ -124,11 +124,6 @@ resource "github_repository_collaborators" "hall-of-fame" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.slug
   }
-
-  team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.slug
-  }
 }
 
 resource "vercel_project" "hall-of-fame" {

--- a/icons.tf
+++ b/icons.tf
@@ -121,11 +121,6 @@ resource "github_repository_collaborators" "icons" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.icons-committer.id
   }

--- a/index.tf
+++ b/index.tf
@@ -113,11 +113,6 @@ resource "github_repository_collaborators" "index" {
     permission = "triage"
     team_id    = github_team.kernteam-triage.id
   }
-
-  team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
 }
 
 resource "github_repository_environment" "index-publish" {

--- a/infra.tf
+++ b/infra.tf
@@ -77,11 +77,6 @@ resource "github_repository_collaborators" "hosting" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.kernteam-maintainer.id
   }

--- a/lux.tf
+++ b/lux.tf
@@ -149,11 +149,6 @@ resource "github_repository_collaborators" "lux" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.logius-committer.id
   }

--- a/nlds-community-blocks.tf
+++ b/nlds-community-blocks.tf
@@ -108,11 +108,6 @@ resource "github_repository_collaborators" "nlds-community-blocks" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.denhaag-draad.id
   }

--- a/rijkshuisstijl-community.tf
+++ b/rijkshuisstijl-community.tf
@@ -147,11 +147,6 @@ resource "github_repository_collaborators" "rijkshuisstijl-community" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.frameless.id
   }

--- a/rotterdam.tf
+++ b/rotterdam.tf
@@ -149,11 +149,6 @@ resource "github_repository_collaborators" "rotterdam" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "maintain"
     team_id    = github_team.gemeente-rotterdam-maintainer.id
   }

--- a/rvo.tf
+++ b/rvo.tf
@@ -135,11 +135,6 @@ resource "github_repository_collaborators" "rvo" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.rvo-committer.id
   }

--- a/team-members.tf
+++ b/team-members.tf
@@ -224,16 +224,6 @@ resource "github_team_members" "kernteam-ci" {
   }
 }
 
-resource "github_team_members" "kernteam-dependabot" {
-  team_id = github_team.kernteam-dependabot.id
-
-  members {
-    username = data.github_user.Robbert.username
-    # organization owners must be "maintainer", see note at https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members
-    role = "maintainer"
-  }
-}
-
 resource "github_team_members" "kernteam-a11y" {
   team_id = github_team.kernteam-a11y.id
 

--- a/team.tf
+++ b/team.tf
@@ -33,13 +33,6 @@ resource "github_team" "kernteam-ci" {
   privacy        = "closed"
 }
 
-resource "github_team" "kernteam-dependabot" {
-  name           = "kernteam-dependabot"
-  description    = "Default reviewers for Dependabot pull requests"
-  parent_team_id = github_team.kernteam.id
-  privacy        = "closed"
-}
-
 resource "github_team" "kernteam-maintainer" {
   name           = "kernteam-maintainer"
   description    = "Can configure GitHub via Terraform, with approval from kernteam-admin."

--- a/terraform.tf
+++ b/terraform.tf
@@ -89,11 +89,6 @@ resource "github_repository_collaborators" "terraform" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.kernteam-committer.id
   }

--- a/themes.tf
+++ b/themes.tf
@@ -115,11 +115,6 @@ resource "github_repository_collaborators" "themes" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.gemeente-amsterdam.id
   }

--- a/tilburg.tf
+++ b/tilburg.tf
@@ -117,11 +117,6 @@ resource "github_repository_collaborators" "tilburg" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.tilburg-committer.id
   }

--- a/utrecht.tf
+++ b/utrecht.tf
@@ -148,11 +148,6 @@ resource "github_repository_collaborators" "utrecht" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.kernteam-committer.id
   }

--- a/wcag-statistieken.tf
+++ b/wcag-statistieken.tf
@@ -90,11 +90,6 @@ resource "github_repository_collaborators" "wcag-statistieken" {
   }
 
   team {
-    permission = "triage"
-    team_id    = github_team.kernteam-dependabot.id
-  }
-
-  team {
     permission = "push"
     team_id    = github_team.expertteam-digitale-toegankelijkheid-committer.id
   }


### PR DESCRIPTION
See: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

Closes https://github.com/nl-design-system/terraform/issues/372

- [x] Wait until all of these are completed: https://github.com/nl-design-system/terraform/issues/372#issuecomment-4026865979
