### PR TITLE
feat: add jurgen-bosma to rvo-committer team

### DIFF
--- a/team-members.tf
+++ b/team-members.tf
@@ -505,25 +505,6 @@ resource "github_team_members" "blueriq-maintainer" {
   }
 }
 
-resource "github_team_members" "rvo" {
-  team_id = github_team.rvo.id
-
-  # Last checked by rvo-maintainer: 2026-04-17
-  members {
-    username = data.github_user.rroose-rvo.username
-  }
-
-  # Last checked by rvo-maintainer: 2026-04-17
-  members {
-    username = data.github_user.shayant98.username
-  }
-
-  # Last checked by rvo-maintainer: 2026-04-21
-  members {
-    username = data.github_user.jurgen-bosma.username
-  }
-}
-
 resource "github_team_members" "rvo-committer" {
   team_id = github_team.rvo-committer.id
 

--- a/team-members.tf
+++ b/team-members.tf
@@ -518,7 +518,7 @@ resource "github_team_members" "rvo" {
     username = data.github_user.shayant98.username
   }
 
-  # Last checked by rvo-maintainer: 2026-04-17
+  # Last checked by rvo-maintainer: 2026-04-21
   members {
     username = data.github_user.jurgen-bosma.username
   }
@@ -600,6 +600,11 @@ resource "github_team_members" "rvo-committer" {
   # Last checked by rvo-maintainer: 2026-04-17
   members {
     username = data.github_user.shayant98.username
+  }
+
+  # Last checked by rvo-maintainer: 2026-04-21
+  members {
+    username = data.github_user.jurgen-bosma.username
   }
 }
 


### PR DESCRIPTION
Navolging op https://github.com/nl-design-system/terraform/pull/596 waar hij enkel in rvo team werd gezet

Daarnaast rvo team verwijderd uit team-members.tf, dit is duplicate ten opzichte van rvo-committer en rvo-maintainer

- [x] Approval van @rroose-rvo als maintainer
- [x] Approval van kernteam 1
- [ ] Approval van kernteam 2