### PR TITLE
ci: disable build cache for documentatie-next

### DIFF
--- a/documentatie.tf
+++ b/documentatie.tf
@@ -203,3 +203,11 @@ resource "vercel_project" "documentatie-next" {
     deployment_type = "none"
   }
 }
+
+resource "vercel_project_environment_variable" "documentatie-next-vercel-force-no-build-cache" {
+  project_id = vercel_project.documentatie-next.id
+  key        = "VERCEL_FORCE_NO_BUILD_CACHE"
+  value      = "1"
+  target     = ["production", "preview"]
+  comment    = "See documentatie#4067"
+}


### PR DESCRIPTION
Should fix rollup/astro errors that only occur on vercel

`documentatie` already done manually

Closes https://github.com/nl-design-system/documentatie/issues/4067
