### PR TITLE
docs: add user Roanheid to community-committer

### DIFF
--- a/team-members.tf
+++ b/team-members.tf
@@ -1098,6 +1098,14 @@ resource "github_team_members" "community-committer" {
     # approximately until 2026-05-31.
     username = data.github_user.MicheleNL.username
   }
+
+  # Last checked by @eslook: 2026-04-30
+  members {
+    # Qalybr working on Angular,
+    # general NL Design System support,
+    # starting with Rijkshuisstijl Community.
+    username = data.github_user.Roanheid.username
+  }
 }
 
 resource "github_team_members" "expertteam-digitale-toegankelijkheid-triage" {

--- a/user.tf
+++ b/user.tf
@@ -629,3 +629,7 @@ data "github_user" "MicheleNL" {
 data "github_user" "jurgen-bosma" {
   username = "jurgen-bosma"
 }
+
+data "github_user" "Roanheid" {
+  username = "Roanheid"
+}


### PR DESCRIPTION
- [x] Community Committer, dus geen maintainer nodig, maar to be fair een approval van Rijkshuisstijl Community maintainer regelen
- [x] Kernteam approval 1
- [x] Kernteam approval 2