### PR TITLE
chore: add new denhaag team member

### DIFF
--- a/denhaag.tf
+++ b/denhaag.tf
@@ -188,7 +188,7 @@ resource "github_repository_collaborators" "denhaag" {
 
   team {
     permission = "push"
-    team_id    = github_team.gemeente-denhaag-design-system.id
+    team_id    = github_team.gemeente-den-haag-committer.id
   }
 
   team {

--- a/team-members.tf
+++ b/team-members.tf
@@ -1002,9 +1002,6 @@ resource "github_team_members" "community-committer" {
   }
 
   # Den Haag folks
-  members {
-    username = data.github_user.jiromaykin.username
-  }
 
   # Kernteam alumni
   members {
@@ -1080,6 +1077,10 @@ resource "github_team_members" "community-committer" {
 
   members {
     username = data.github_user.sergei-maertens.username
+  }
+
+  members {
+    username = data.github_user.jiromaykin.username
   }
 
   # Last checked by @Robbert: 2026-04-20

--- a/team-members.tf
+++ b/team-members.tf
@@ -1002,6 +1002,13 @@ resource "github_team_members" "community-committer" {
   }
 
   # Den Haag folks
+  members {
+    username = data.github_user.Borai.username
+  }
+
+  members {
+    username = data.github_user.YourivHDenHaag.username
+  }
 
   # Kernteam alumni
   members {

--- a/team-members.tf
+++ b/team-members.tf
@@ -438,6 +438,14 @@ resource "github_team_members" "gemeente-den-haag-maintainer" {
   }
 }
 
+resource "github_team_members" "gemeente-den-haag-committer" {
+  team_id = github_team.gemeente-den-haag-committer.id
+
+  members {
+    username = data.github_user.flinden68.username
+  }
+}
+
 resource "github_team_members" "gemeente-denhaag-acato-committer" {
   team_id = github_team.gemeente-denhaag-acato-committer.id
 
@@ -1008,6 +1016,10 @@ resource "github_team_members" "community-committer" {
 
   members {
     username = data.github_user.YourivHDenHaag.username
+  }
+
+  members {
+    username = data.github_user.flinden68.username
   }
 
   # Kernteam alumni

--- a/team.tf
+++ b/team.tf
@@ -81,10 +81,10 @@ resource "github_team" "gemeente-denhaag-admin" {
   privacy        = "closed"
 }
 
-resource "github_team" "gemeente-denhaag-design-system" {
-  name           = "gemeente-denhaag-design-system"
+resource "github_team" "gemeente-den-haag-committer" {
+  name           = "gemeente-den-haag-committer"
   parent_team_id = github_team.gemeente-den-haag.id
-  description    = "Den Haag System team"
+  description    = "Can create pull requests in the Den Haag Design System repository"
   privacy        = "closed"
 }
 

--- a/user.tf
+++ b/user.tf
@@ -374,6 +374,10 @@ data "github_user" "YourivHDenHaag" {
   username = "YourivHDenHaag"
 }
 
+data "github_user" "flinden68" {
+  username = "flinden68"
+}
+
 data "github_user" "ZencakeTheBob" {
   username = "ZencakeTheBob"
 }


### PR DESCRIPTION
Ik werd gevraagd een nieuwe Codeowner Frank van der Linden toe te voegen bij Den Haag. Het leek me goed die persoon gelijk toe te voegen via Terraform met de juiste rechten.

Toen ik dat ging doen zag ik dat het Den Haag team verder nog niet helemaal aan de conventies voldeed, dus ik heb gelijk wat cub-scouting gedaan. ✨ 

- Jiro stond onder Den Haag, maar moest eigenlijk bij Maykin staan voor de duidelijkheid
- Den Haag team was nog helemaal geen onderdeel van community committers. Wel logisch als ze dat wel zijn, dus toegevoegd.
- Den Haag had een committer team, maar dat heette design-system. Ik heb die hernoemd.
- En dan eindelijk de nieuwe team member toegevoegd