### PR TITLE
ci: don't persist credentials in actions/checkout

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0


### PR DESCRIPTION
This PR updates the `actions/checkout` action to not persist credentials by default.

This is a security best practice.

See https://github.com/nl-design-system/beheer/issues/31 for more details.
