### PR TITLE
ci: allow installation of zizmor in GitHub Actions

### DIFF
--- a/github_organization.tf
+++ b/github_organization.tf
@@ -22,6 +22,7 @@ resource "github_actions_organization_permissions" "nl-design-system" {
       "php-actions/composer@*",
       "pnpm/action-setup@*",
       "slackapi/slack-github-action@*",
+      "zizmorcore/zizmor-action@*",
       # Third party individually owned actions
       "amannn/action-semantic-pull-request@*",
       "JamesIves/github-pages-deploy-action@*",


### PR DESCRIPTION
zizmor will be used for linting GitHub Actions

We'll start with candidate.  See: https://github.com/nl-design-system/beheer/issues/76