### PR TITLE
ci: enable tag protection across all repos

### DIFF
--- a/architectuur.tf
+++ b/architectuur.tf
@@ -96,6 +96,36 @@ resource "github_repository_ruleset" "architectuur-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "architectuur-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.architectuur.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "architectuur" {
   repository = github_repository.architectuur.name
 

--- a/backlog.tf
+++ b/backlog.tf
@@ -64,6 +64,36 @@ resource "github_repository_ruleset" "backlog-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "backlog-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.backlog.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "backlog" {
   repository = github_repository.backlog.name
 

--- a/basis.tf
+++ b/basis.tf
@@ -98,6 +98,36 @@ resource "github_repository_ruleset" "basis-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "basis-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.basis.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "basis" {
   repository = github_repository.basis.name
 

--- a/beheer.tf
+++ b/beheer.tf
@@ -64,6 +64,36 @@ resource "github_repository_ruleset" "beheer-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "beheer-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.beheer.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "beheer" {
   repository = github_repository.beheer.name
 

--- a/candidate.tf
+++ b/candidate.tf
@@ -102,6 +102,36 @@ resource "github_repository_ruleset" "candidate-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "candidate-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.candidate.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "candidate" {
   repository = github_repository.candidate.name
 

--- a/denhaag.tf
+++ b/denhaag.tf
@@ -158,6 +158,36 @@ resource "github_repository_ruleset" "denhaag-other" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "denhaag-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.denhaag.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "denhaag" {
   repository = github_repository.denhaag.name
 

--- a/documentatie.tf
+++ b/documentatie.tf
@@ -115,6 +115,36 @@ resource "github_repository_ruleset" "documentatie-other" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "documentatie-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.documentatie.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "documentatie" {
   repository = github_repository.documentatie.name
 

--- a/dot-github.tf
+++ b/dot-github.tf
@@ -62,6 +62,36 @@ resource "github_repository_ruleset" "dot-github-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "dot-github-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.dot-github.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "dot-github" {
   repository = github_repository.dot-github.name
 

--- a/example-with-angular.tf
+++ b/example-with-angular.tf
@@ -90,6 +90,36 @@ resource "github_repository_ruleset" "example-with-angular-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "example-with-angular-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.example-with-angular.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "example-with-angular" {
   repository = github_repository.example-with-angular.name
 

--- a/example.tf
+++ b/example.tf
@@ -91,6 +91,36 @@ resource "github_repository_ruleset" "example-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "example-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.example.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "example" {
   repository = github_repository.example.name
 

--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -90,6 +90,36 @@ resource "github_repository_ruleset" "gebruikersonderzoeken-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "gebruikersonderzoeken-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.gebruikersonderzoeken.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "gebruikersonderzoeken" {
   repository = github_repository.gebruikersonderzoeken.name
 

--- a/hall-of-fame.tf
+++ b/hall-of-fame.tf
@@ -120,6 +120,36 @@ resource "github_repository_ruleset" "hall-of-fame-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "hall-of-fame-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.hall-of-fame.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "hall-of-fame" {
   repository = github_repository.hall-of-fame.name
 

--- a/icons.tf
+++ b/icons.tf
@@ -97,6 +97,36 @@ resource "github_repository_ruleset" "cons-main" {
 }
 
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "icons-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.icons.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "icons" {
   repository = github_repository.icons.name
 

--- a/index.tf
+++ b/index.tf
@@ -86,6 +86,36 @@ resource "github_repository_ruleset" "index-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "index-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.index.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "index" {
   repository = github_repository.index.name
 

--- a/infra.tf
+++ b/infra.tf
@@ -66,6 +66,36 @@ resource "github_repository_ruleset" "hosting-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "hosting-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.hosting.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "hosting" {
   repository = github_repository.hosting.name
 

--- a/lux.tf
+++ b/lux.tf
@@ -125,6 +125,36 @@ resource "github_repository_ruleset" "lux-other" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "lux-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.lux.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "lux" {
   repository = github_repository.lux.name
 

--- a/mijn-services.tf
+++ b/mijn-services.tf
@@ -85,6 +85,36 @@ resource "github_repository_ruleset" "mijn-services-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "mijn-services-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.mijn-services.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "mijn-services" {
   repository = github_repository.mijn-services.name
 

--- a/nlds-community-blocks.tf
+++ b/nlds-community-blocks.tf
@@ -84,6 +84,36 @@ resource "github_repository_ruleset" "nlds-community-blocks-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "nlds-community-blocks-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.nlds-community-blocks.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "nlds-community-blocks" {
   repository = github_repository.nlds-community-blocks.name
 

--- a/rijkshuisstijl-community.tf
+++ b/rijkshuisstijl-community.tf
@@ -123,6 +123,36 @@ resource "github_repository_ruleset" "rijkshuisstijl-community-other" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "rijkshuisstijl-community-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.rijkshuisstijl-community.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "rijkshuisstijl-community" {
   repository = github_repository.rijkshuisstijl-community.name
 

--- a/rotterdam.tf
+++ b/rotterdam.tf
@@ -125,6 +125,36 @@ resource "github_repository_ruleset" "rotterdam-other" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "rotterdam-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.rotterdam.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "rotterdam" {
   repository = github_repository.rotterdam.name
 

--- a/rvo.tf
+++ b/rvo.tf
@@ -111,6 +111,36 @@ resource "github_repository_ruleset" "rvo-other" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "rvo-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.rvo.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "rvo" {
   repository = github_repository.rvo.name
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -78,6 +78,36 @@ resource "github_repository_ruleset" "terraform-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "terraform-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.terraform.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "terraform" {
   repository = github_repository.terraform.name
 

--- a/theme-wizard.tf
+++ b/theme-wizard.tf
@@ -85,6 +85,36 @@ resource "github_repository_ruleset" "theme-wizard-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "theme-wizard-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.theme-wizard.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "theme-wizard" {
   repository = github_repository.theme-wizard.name
 

--- a/themes.tf
+++ b/themes.tf
@@ -91,6 +91,36 @@ resource "github_repository_ruleset" "themes-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "themes-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.themes.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "themes" {
   repository = github_repository.themes.name
 

--- a/tilburg.tf
+++ b/tilburg.tf
@@ -93,6 +93,36 @@ resource "github_repository_ruleset" "tilburg-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "tilburg-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.tilburg.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "tilburg" {
   repository = github_repository.tilburg.name
 

--- a/wcag-statistieken.tf
+++ b/wcag-statistieken.tf
@@ -76,6 +76,36 @@ resource "github_repository_ruleset" "wcag-statistieken-main" {
   }
 }
 
+# Only allow the `nl-design-system-ci` user to manage Git tags
+resource "github_repository_ruleset" "wcag-statistieken-tag" {
+  enforcement = "active"
+  name        = "tag-protection"
+  repository  = github_repository.wcag-statistieken.name
+  target      = "tag"
+
+  bypass_actors {
+    actor_id    = github_team.kernteam-ci.id
+    actor_type  = "Team"
+    bypass_mode = "always"
+  }
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    creation                = true
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+    required_signatures     = true
+    update                  = true
+  }
+}
+
 resource "github_repository_collaborators" "wcag-statistieken" {
   repository = github_repository.wcag-statistieken.name
 


### PR DESCRIPTION
This will prevent tags from being created (or removed, etc.) by any user except the CI user.

Good to know:
- utrecht and editor already had this protection
- rotterdam is the only repo actively using tags (`java-*`).  There is a separate deployment policy that only allows `java-*` tags to publish and the added tag protection should not affect this workflow.
- right now the only other tags are the ones created by changesets.  This will work fine if the workflow is run with the correct user (nl-design-system-ci).  I've verified all workflows that they use a separate token (`GH_TOKEN` instead of `GITHUB_TOKEN`).

closes https://github.com/nl-design-system/terraform/pull/612