### PR TITLE
ci: configure dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 1
     groups:
       github-actions:
         applies-to: "version-updates"
@@ -14,7 +16,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 1
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 1


### PR DESCRIPTION
This PR configures the [cooldown](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) for dependabot updates to 1 day.

This is a security measure that gives the ecosystem enough time to flag malicious packages before they reach our codebase.

It is already configured in pnpm and npm-check-updates, but not in dependabot.  Thanks to zizmor for flagging.
