### PR TITLE
chore: upgrade pnpm to 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "engines": {
     "node": ">=24 <=25",
-    "pnpm": "^10.17.0"
+    "pnpm": "^11.4.0"
   },
   "scripts": {
     "prepare": "husky",
@@ -9,7 +9,7 @@
     "lint-fix": "prettier --write ."
   },
   "license": "EUPL-1.2",
-  "packageManager": "pnpm@10.30.1+sha512.3590e550d5384caa39bd5c7c739f72270234b2f6059e13018f975c313b1eb9fefcc09714048765d4d9efe961382c312e624572c0420762bdc5d5940cdf9be73a",
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
   "devDependencies": {
     "husky": "9.1.7",
     "prettier": "3.8.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,5 @@ minimumReleaseAge: 1440
 saveExact: true
 
 savePrefix: ''
+
+ignoreScripts: true


### PR DESCRIPTION
This PR upgrades pnpm to the latest version.  pnpm 11 has been out for a while now, and is now the recommended version to use.  Set the minimum version to 11.4 since that is the latest version with security fixes.  To use pnpm 11, ensure you're on a recent version of Node and run `corepack enable` in the root of the repository.

```sh
# to use the version of pnpm as specified in package.json
corepack enable
```

[pnpm 11](https://pnpm.io/blog/releases/11.0#highlights) comes with breaking changes and the [migration guide](https://pnpm.io/migration) was used.  It comes with better defaults for [strictDepBuilds](https://pnpm.io/settings#strictdepbuilds): you must now explicitly review which build scripts are allowed.  As well as `blockExoticSubdeps`.

The automigration moved all properties from `.npmrc` to `pnpm-workspace.yaml`, but we want to keep `ignore-scripts` as a safety measure and `provenance` because changeset publish bypasses pnpm.

`minimumReleaseAge` by default is now 24h, same as our existing setting.  I still kept it in `pnpm-workspace.yaml`, as it doesn't hurt to be explicit about it.

Also cleaned up the workaround in pipelines that allowed an RC version of pnpm to be used when the npm audit endpoint was down.  With pnpm 11, this is no longer needed.
