### PR TITLE
ci: disable required code owner review for rvo

### DIFF
--- a/rvo.tf
+++ b/rvo.tf
@@ -80,7 +80,7 @@ resource "github_repository_ruleset" "rvo-master" {
 
     pull_request {
       dismiss_stale_reviews_on_push     = true
-      require_code_owner_review         = true
+      require_code_owner_review         = false
       require_last_push_approval        = false
       required_approving_review_count   = 1
       required_review_thread_resolution = true


### PR DESCRIPTION
This matches existing behavior before rvo#1625 was merged.
