### PR TITLE
ci: fix overly broad permissions, and increase minRlsAge to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 1
+      default-days: 7
     groups:
       github-actions:
         applies-to: "version-updates"
@@ -17,10 +17,10 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 1
+      default-days: 7
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 1
+      default-days: 7

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,10 +1,15 @@
 name: Terraform
 on: pull_request
 
+permissions: {}
+
 jobs:
   terraform:
     name: Terraform format check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 engineStrict: true
 
-minimumReleaseAge: 1440
+minimumReleaseAge: 10080 # 7 days
 
 saveExact: true
 


### PR DESCRIPTION
While we use 1 day for most repos, this repo deals with more sensitive stuff so we opt for the zizmor-suggested age of 7 days.

Fixed the overly broad permissions in the workflow.
