### PR TITLE
chore: remove user shayant98

### DIFF
--- a/team-members.tf
+++ b/team-members.tf
@@ -618,11 +618,6 @@ resource "github_team_members" "rvo-committer" {
     username = data.github_user.fKasteleinDictu.username
   }
 
-  # Last checked by rvo-maintainer: 2026-04-17
-  members {
-    username = data.github_user.shayant98.username
-  }
-
   # Last checked by rvo-maintainer: 2026-04-21
   members {
     username = data.github_user.jurgen-bosma.username

--- a/user.tf
+++ b/user.tf
@@ -158,10 +158,6 @@ data "github_user" "savitris" {
   username = "savitris"
 }
 
-data "github_user" "shayant98" {
-  username = "shayant98"
-}
-
 data "github_user" "hansregeer" {
   username = "hansregeer"
 }


### PR DESCRIPTION
User was added three months ago and hasn't accepted GitHub invitation. Verified with kernteam that user is no longer working for RVO.

- [x] Kernteam approval 1
- [x] Kernteam approval 2
- Geen maintainer approval nodig: gebruiker heeft nooit GitHub uitnodiging geaccepteerd en is niet meer werkzaam bij RVO.