### PR TITLE
ci: manage vercel projects through terraform (batch 1/2)

### DIFF
--- a/architectuur.tf
+++ b/architectuur.tf
@@ -157,8 +157,6 @@ resource "github_repository_collaborators" "architectuur" {
 
 resource "vercel_project" "architectuur" {
   name                    = github_repository.architectuur.name
-  output_directory        = "dist/"
-  ignore_command          = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
   node_version            = "24.x"
   enable_preview_feedback = false
 

--- a/candidate.tf
+++ b/candidate.tf
@@ -225,3 +225,24 @@ resource "vercel_project" "candidate-storybook-test" {
     deployment_type = "none"
   }
 }
+
+resource "vercel_project" "evil-storybook" {
+  name                    = "evil-storybook"
+  node_version            = "24.x"
+  root_directory          = "packages/storybook-non-conforming/"
+  enable_preview_feedback = false
+
+  git_repository = {
+    type = "github"
+    repo = github_repository.candidate.full_name
+  }
+
+  vercel_authentication = {
+    deployment_type = "none"
+  }
+}
+
+import {
+  to = vercel_project.evil-storybook
+  id = "prj_iRc47wOfQyznUl39sccYm5UgtSwl"
+}

--- a/candidate.tf
+++ b/candidate.tf
@@ -180,9 +180,8 @@ resource "github_repository_environment_deployment_policy" "candidate-publish-ma
 
 resource "vercel_project" "candidate" {
   name                    = github_repository.candidate.name
-  output_directory        = "packages/storybook/dist"
-  ignore_command          = "[[ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" == \"dependabot[bot]\" ]]"
   node_version            = "24.x"
+  root_directory          = "packages/storybook/"
   enable_preview_feedback = false
 
   git_repository = {
@@ -197,9 +196,8 @@ resource "vercel_project" "candidate" {
 
 resource "vercel_project" "candidate-storybook-non-conforming" {
   name                    = "candidate-storybook-non-conforming"
-  output_directory        = "packages/storybook-non-conforming/dist/"
-  ignore_command          = "[[ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" == \"dependabot[bot]\" ]]"
   node_version            = "24.x"
+  root_directory          = "packages/storybook-non-conforming/"
   enable_preview_feedback = false
 
   git_repository = {
@@ -214,9 +212,8 @@ resource "vercel_project" "candidate-storybook-non-conforming" {
 
 resource "vercel_project" "candidate-storybook-test" {
   name                    = "candidate-storybook-test"
-  output_directory        = "packages/storybook-test/dist/"
-  ignore_command          = "[[ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" == \"dependabot[bot]\" ]]"
   node_version            = "24.x"
+  root_directory          = "packages/storybook-test/"
   enable_preview_feedback = false
 
   git_repository = {

--- a/candidate.tf
+++ b/candidate.tf
@@ -210,6 +210,11 @@ resource "vercel_project" "candidate-storybook-non-conforming" {
   }
 }
 
+resource "vercel_project_domain" "candidate-storybook-non-conforming-evil-storybook" {
+  project_id = vercel_project.candidate-storybook-non-conforming.id
+  domain     = "evil-storybook.vercel.app"
+}
+
 resource "vercel_project" "candidate-storybook-test" {
   name                    = "candidate-storybook-test"
   node_version            = "24.x"
@@ -224,25 +229,4 @@ resource "vercel_project" "candidate-storybook-test" {
   vercel_authentication = {
     deployment_type = "none"
   }
-}
-
-resource "vercel_project" "evil-storybook" {
-  name                    = "evil-storybook"
-  node_version            = "24.x"
-  root_directory          = "packages/storybook-non-conforming/"
-  enable_preview_feedback = false
-
-  git_repository = {
-    type = "github"
-    repo = github_repository.candidate.full_name
-  }
-
-  vercel_authentication = {
-    deployment_type = "none"
-  }
-}
-
-import {
-  to = vercel_project.evil-storybook
-  id = "prj_iRc47wOfQyznUl39sccYm5UgtSwl"
 }

--- a/denhaag.tf
+++ b/denhaag.tf
@@ -280,3 +280,24 @@ resource "github_repository_environment_deployment_policy" "denhaag-www-denhaag-
   environment    = github_repository_environment.denhaag-www-denhaag-nl.environment
   branch_pattern = "www.denhaag.nl"
 }
+
+resource "vercel_project" "denhaag" {
+  name                    = github_repository.denhaag.name
+  node_version            = "24.x"
+  root_directory          = "packages/storybook/"
+  enable_preview_feedback = false
+
+  git_repository = {
+    type = "github"
+    repo = github_repository.denhaag.full_name
+  }
+
+  vercel_authentication = {
+    deployment_type = "none"
+  }
+}
+
+import {
+  to = vercel_project.denhaag
+  id = "prj_Vja9NNSvsdhWTffDOIS5xyis45en"
+}

--- a/documentatie.tf
+++ b/documentatie.tf
@@ -211,6 +211,27 @@ resource "github_repository_webhook" "documentatie" {
   }
 }
 
+resource "vercel_project" "documentatie" {
+  name                    = "documentatie"
+  node_version            = "24.x"
+  root_directory          = "packages/website/"
+  enable_preview_feedback = false
+
+  git_repository = {
+    type = "github"
+    repo = github_repository.documentatie.full_name
+  }
+
+  vercel_authentication = {
+    deployment_type = "none"
+  }
+}
+
+import {
+  to = vercel_project.documentatie
+  id = "prj_DjlWyhwNElZu2MqbAbRzN2AJUdl1"
+}
+
 resource "vercel_project" "documentatie-next" {
   name                    = "documentatie-next"
   node_version            = "24.x"

--- a/documentatie.tf
+++ b/documentatie.tf
@@ -213,10 +213,8 @@ resource "github_repository_webhook" "documentatie" {
 
 resource "vercel_project" "documentatie-next" {
   name                    = "documentatie-next"
-  build_command           = "pnpm --filter @nl-design-system/website-astro run build"
-  output_directory        = "packages/website/dist/"
-  ignore_command          = "[[ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" == \"dependabot[bot]\" || \"$VERCEL_GIT_COMMIT_REF\" == \"gh-pages\" ]]"
   node_version            = "24.x"
+  root_directory          = "packages/website/"
   enable_preview_feedback = false
 
   git_repository = {

--- a/example-with-angular.tf
+++ b/example-with-angular.tf
@@ -158,3 +158,23 @@ resource "github_repository_collaborators" "example-with-angular" {
     team_id    = github_team.community-contributor.id
   }
 }
+
+resource "vercel_project" "example-with-angular" {
+  name                    = github_repository.example-with-angular.name
+  node_version            = "24.x"
+  enable_preview_feedback = false
+
+  git_repository = {
+    type = "github"
+    repo = github_repository.example-with-angular.full_name
+  }
+
+  vercel_authentication = {
+    deployment_type = "none"
+  }
+}
+
+import {
+  to = vercel_project.example-with-angular
+  id = "prj_lKVjJtxSgYnDixa5okzZuubUBsj7"
+}

--- a/example.tf
+++ b/example.tf
@@ -149,3 +149,24 @@ resource "github_repository_collaborators" "example" {
     team_id    = github_team.community-contributor.id
   }
 }
+
+resource "vercel_project" "example" {
+  name                    = github_repository.example.name
+  node_version            = "24.x"
+  root_directory          = "packages/storybook/"
+  enable_preview_feedback = false
+
+  git_repository = {
+    type = "github"
+    repo = github_repository.example.full_name
+  }
+
+  vercel_authentication = {
+    deployment_type = "none"
+  }
+}
+
+import {
+  to = vercel_project.example
+  id = "prj_HJOXF8WPwXtemQdLQe71VFQi7d9z"
+}

--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -188,10 +188,8 @@ resource "github_repository_environment_deployment_policy" "gebruikersonderzoeke
 
 resource "vercel_project" "gebruikersonderzoeken" {
   name                    = "gebruikersonderzoeken"
-  output_directory        = "packages/website/dist/"
-  build_command           = "pnpm run build"
-  ignore_command          = "[[ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" == \"dependabot[bot]\" || \"$VERCEL_GIT_COMMIT_REF\" == \"gh-pages\" ]]"
   node_version            = "24.x"
+  root_directory          = "packages/website/"
   enable_preview_feedback = false
 
   git_repository = {

--- a/hall-of-fame.tf
+++ b/hall-of-fame.tf
@@ -178,9 +178,8 @@ resource "github_repository_environment_deployment_policy" "hall-of-fame-publish
 
 resource "vercel_project" "hall-of-fame" {
   name                    = github_repository.hall-of-fame.name
-  output_directory        = "packages/storybook/dist"
-  ignore_command          = "[[ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" == \"dependabot[bot]\" ]]"
   node_version            = "24.x"
+  root_directory          = "packages/storybook/"
   enable_preview_feedback = false
 
   git_repository = {

--- a/icons.tf
+++ b/icons.tf
@@ -180,9 +180,8 @@ resource "github_repository_environment_deployment_policy" "icons-publish-main" 
 
 resource "vercel_project" "icons" {
   name                    = github_repository.icons.name
-  output_directory        = "packages/storybook/dist/"
-  ignore_command          = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
   node_version            = "24.x"
+  root_directory          = "packages/storybook/"
   enable_preview_feedback = false
 
   git_repository = {

--- a/themes.tf
+++ b/themes.tf
@@ -346,3 +346,24 @@ resource "github_repository_environment_deployment_policy" "themes-publish-main"
   environment    = github_repository_environment.themes-publish.environment
   branch_pattern = github_branch_default.themes.branch
 }
+
+resource "vercel_project" "themes" {
+  name                    = github_repository.themes.name
+  node_version            = "24.x"
+  root_directory          = "packages/storybook/"
+  enable_preview_feedback = false
+
+  git_repository = {
+    type = "github"
+    repo = github_repository.themes.full_name
+  }
+
+  vercel_authentication = {
+    deployment_type = "none"
+  }
+}
+
+import {
+  to = vercel_project.themes
+  id = "prj_7bWTMu04WBTwpFF1VmHuhQ23zxSt"
+}


### PR DESCRIPTION
1. Imports vercel projects that were manually created
2. Removes configuration that should be in vercel.json.  vercel.json will now live in the package folder (so preferably not in the root) to accomodate for having multiple vercel deployments per repo.  So this is why rootDirectory is added for every project.
3. Skipping dependabot/gh-pages deployments is done through vercel.json so this is also removed from terraform.
4. evil-storybook vercel project was not managed by terraform, this was manually removed. In this PR, the domain was added to candidate-storybook-non-conforming.

Because of (2), these need to be merged first:
- https://github.com/nl-design-system/example/pull/1014
- https://github.com/nl-design-system/architectuur/pull/77
- https://github.com/nl-design-system/candidate/pull/1285
- https://github.com/nl-design-system/denhaag/pull/2100
- https://github.com/nl-design-system/documentatie/pull/4418
- https://github.com/nl-design-system/example-with-angular/pull/1030
- https://github.com/nl-design-system/gebruikersonderzoeken/pull/813
- https://github.com/nl-design-system/hall-of-fame/pull/123
- https://github.com/nl-design-system/icons/pull/195
- https://github.com/nl-design-system/themes/pull/1541