### PR TITLE
ci: manage vercel projects through terraform (batch 2/2)

### DIFF
--- a/architectuur.tf
+++ b/architectuur.tf
@@ -169,3 +169,13 @@ resource "vercel_project" "architectuur" {
     deployment_type = "none"
   }
 }
+
+resource "vercel_project_domain" "architectuur" {
+  project_id = vercel_project.architectuur.id
+  domain     = "architectuur.vercel.app"
+}
+
+import {
+  to = vercel_project_domain.architectuur
+  id = "prj_ZugY0Z5IIfMacdMaZVwgp2m0JEKD/architectuur-tmp.vercel.app"
+}

--- a/documentatie.tf
+++ b/documentatie.tf
@@ -217,6 +217,11 @@ resource "vercel_project" "documentatie" {
   root_directory          = "packages/website/"
   enable_preview_feedback = false
 
+  # Skipping deployment for static file branches must be configured at the
+  # project level instead of vercel.json, because vercel.json does not exist in
+  # those branches.
+  ignore_command = "[[ \"$VERCEL_GIT_COMMIT_REF\" == \"gh-pages\" || \"$VERCEL_GIT_COMMIT_REF\" == \"assets\" ]]"
+
   git_repository = {
     type = "github"
     repo = github_repository.documentatie.full_name
@@ -237,6 +242,11 @@ resource "vercel_project" "documentatie-next" {
   node_version            = "24.x"
   root_directory          = "packages/website/"
   enable_preview_feedback = false
+
+  # Skipping deployment for static file branches must be configured at the
+  # project level instead of vercel.json, because vercel.json does not exist in
+  # those branches.
+  ignore_command = "[[ \"$VERCEL_GIT_COMMIT_REF\" == \"gh-pages\" || \"$VERCEL_GIT_COMMIT_REF\" == \"assets\" ]]"
 
   git_repository = {
     type = "github"

--- a/editor.tf
+++ b/editor.tf
@@ -178,10 +178,8 @@ resource "github_repository_environment_deployment_policy" "editor-publish-main"
 
 resource "vercel_project" "editor" {
   name                    = "editor"
-  output_directory        = "packages/website/dist/"
-  build_command           = "pnpm run build"
-  ignore_command          = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
   node_version            = "24.x"
+  root_directory          = "packages/editor-website/"
   enable_preview_feedback = false
 
   git_repository = {
@@ -193,4 +191,3 @@ resource "vercel_project" "editor" {
     deployment_type = "none"
   }
 }
-

--- a/editor.tf
+++ b/editor.tf
@@ -191,3 +191,13 @@ resource "vercel_project" "editor" {
     deployment_type = "none"
   }
 }
+
+resource "vercel_project_domain" "editor" {
+  project_id = vercel_project.editor.id
+  domain     = "editor.nl-design-system-community.nl"
+}
+
+import {
+  to = vercel_project_domain.editor
+  id = "prj_QWTqgKfcnOPsbzseNOaS9OAvAcom/editor.nl-design-system-community.nl"
+}

--- a/gebruikersonderzoeken.tf
+++ b/gebruikersonderzoeken.tf
@@ -192,6 +192,11 @@ resource "vercel_project" "gebruikersonderzoeken" {
   root_directory          = "packages/website/"
   enable_preview_feedback = false
 
+  # Skipping deployment for static file branches must be configured at the
+  # project level instead of vercel.json, because vercel.json does not exist in
+  # those branches.
+  ignore_command = "[[ \"$VERCEL_GIT_COMMIT_REF\" == \"gh-pages\" || \"$VERCEL_GIT_COMMIT_REF\" == \"assets\" ]]"
+
   git_repository = {
     type = "github"
     repo = github_repository.gebruikersonderzoeken.full_name

--- a/lux.tf
+++ b/lux.tf
@@ -210,3 +210,34 @@ resource "github_repository_environment_deployment_policy" "lux-publish-main" {
   environment    = github_repository_environment.lux-publish.environment
   branch_pattern = github_branch_default.lux.branch
 }
+
+resource "vercel_project" "lux" {
+  name                    = github_repository.lux.name
+  node_version            = "24.x"
+  root_directory          = "packages/storybook/"
+  enable_preview_feedback = false
+
+  git_repository = {
+    type = "github"
+    repo = github_repository.lux.full_name
+  }
+
+  vercel_authentication = {
+    deployment_type = "none"
+  }
+}
+
+resource "vercel_project_domain" "lux" {
+  project_id = vercel_project.lux.id
+  domain     = "lux-storybook.vercel.app"
+}
+
+import {
+  to = vercel_project.lux
+  id = "prj_fYC2rZmm0TarTaAwsW5zNISPeSmM"
+}
+
+import {
+  to = vercel_project_domain.lux
+  id = "prj_fYC2rZmm0TarTaAwsW5zNISPeSmM/lux-storybook.vercel.app"
+}

--- a/mijn-services.tf
+++ b/mijn-services.tf
@@ -185,9 +185,8 @@ resource "github_repository_environment" "mijn-services-maintenance" {
 
 resource "vercel_project" "mijn-services" {
   name                    = github_repository.mijn-services.name
-  output_directory        = "packages/storybook/dist/"
-  ignore_command          = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
   node_version            = "24.x"
+  root_directory          = "packages/storybook/"
   enable_preview_feedback = false
 
   git_repository = {

--- a/rijkshuisstijl-community.tf
+++ b/rijkshuisstijl-community.tf
@@ -251,9 +251,8 @@ resource "github_repository_environment_deployment_policy" "rijkshuisstijl-commu
 
 resource "vercel_project" "rijkshuisstijl-community" {
   name                    = "rijkshuisstijl-community"
-  output_directory        = "packages/storybook/dist/"
-  ignore_command          = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
   node_version            = "24.x"
+  root_directory          = "packages/storybook/"
   enable_preview_feedback = false
 
   git_repository = {
@@ -268,9 +267,8 @@ resource "vercel_project" "rijkshuisstijl-community" {
 
 resource "vercel_project" "rijkshuisstijl-community-templates" {
   name                    = "rijkshuisstijl-community-templates"
-  output_directory        = "apps/rhc-templates/dist/"
-  ignore_command          = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
   node_version            = "24.x"
+  root_directory          = "apps/rhc-templates/"
   enable_preview_feedback = false
 
   git_repository = {
@@ -285,9 +283,8 @@ resource "vercel_project" "rijkshuisstijl-community-templates" {
 
 resource "vercel_project" "rijkshuisstijl-community-storybook-angular" {
   name                    = "rijkshuisstijl-community-storybook-angular"
-  output_directory        = "packages/storybook-angular/dist/"
-  ignore_command          = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
   node_version            = "24.x"
+  root_directory          = "packages/storybook-angular/"
   enable_preview_feedback = false
 
   git_repository = {

--- a/rotterdam.tf
+++ b/rotterdam.tf
@@ -226,3 +226,34 @@ resource "github_repository_environment_deployment_policy" "rotterdam-publish-ja
   environment = github_repository_environment.rotterdam-publish.environment
   tag_pattern = "java-*"
 }
+
+resource "vercel_project" "rotterdam" {
+  name                    = github_repository.rotterdam.name
+  node_version            = "24.x"
+  root_directory          = "packages/storybook/"
+  enable_preview_feedback = false
+
+  git_repository = {
+    type = "github"
+    repo = github_repository.rotterdam.full_name
+  }
+
+  vercel_authentication = {
+    deployment_type = "none"
+  }
+}
+
+resource "vercel_project_domain" "rotterdam" {
+  project_id = vercel_project.rotterdam.id
+  domain     = "rotterdam-design-system.vercel.app"
+}
+
+import {
+  to = vercel_project.rotterdam
+  id = "prj_I8G4CKGz2Enm6RaghP1fbtWyeO73"
+}
+
+import {
+  to = vercel_project_domain.rotterdam
+  id = "prj_I8G4CKGz2Enm6RaghP1fbtWyeO73/rotterdam-design-system.vercel.app"
+}

--- a/rvo.tf
+++ b/rvo.tf
@@ -196,3 +196,34 @@ resource "github_repository_environment_deployment_policy" "rvo-publish-main" {
   environment    = github_repository_environment.rvo-publish.environment
   branch_pattern = github_branch_default.rvo.branch
 }
+
+resource "vercel_project" "rvo" {
+  name                    = github_repository.rvo.name
+  node_version            = "24.x"
+  root_directory          = "packages/design-system-website/"
+  enable_preview_feedback = false
+
+  git_repository = {
+    type = "github"
+    repo = github_repository.rvo.full_name
+  }
+
+  vercel_authentication = {
+    deployment_type = "none"
+  }
+}
+
+resource "vercel_project_domain" "rvo" {
+  project_id = vercel_project.rvo.id
+  domain     = "rvo.vercel.app"
+}
+
+import {
+  to = vercel_project.rvo
+  id = "prj_bGmJFB5eIHn17QmWGcbjEWbqXPRv"
+}
+
+import {
+  to = vercel_project_domain.rvo
+  id = "prj_bGmJFB5eIHn17QmWGcbjEWbqXPRv/rvo.vercel.app"
+}

--- a/text-alternative-tests.tf
+++ b/text-alternative-tests.tf
@@ -180,23 +180,3 @@ resource "github_repository_environment_deployment_policy" "text-alternative-tes
   environment    = github_repository_environment.text-alternative-tests-publish.environment
   branch_pattern = github_branch_default.text-alternative-tests.branch
 }
-
-
-resource "vercel_project" "text-alternative-tests" {
-  name                    = "text-alternative-tests"
-  output_directory        = "packages/website/dist/"
-  build_command           = "pnpm run build"
-  ignore_command          = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
-  node_version            = "24.x"
-  enable_preview_feedback = false
-
-  git_repository = {
-    type = "github"
-    repo = github_repository.text-alternative-tests.full_name
-  }
-
-  vercel_authentication = {
-    deployment_type = "none"
-  }
-}
-

--- a/theme-wizard.tf
+++ b/theme-wizard.tf
@@ -204,6 +204,16 @@ resource "vercel_project" "theme-wizard" {
   }
 }
 
+resource "vercel_project_domain" "theme-wizard" {
+  project_id = vercel_project.theme-wizard.id
+  domain     = "theme-wizard.nl-design-system-community.nl"
+}
+
+import {
+  to = vercel_project_domain.theme-wizard
+  id = "prj_0PZgYT8FcC8BBUQa7GJqzvIQeBCB/theme-wizard.nl-design-system-community.nl"
+}
+
 resource "vercel_project" "theme-wizard-server" {
   name                                              = "theme-wizard-server"
   node_version                                      = "24.x"
@@ -220,6 +230,16 @@ resource "vercel_project" "theme-wizard-server" {
   vercel_authentication = {
     deployment_type = "none"
   }
+}
+
+resource "vercel_project_domain" "theme-wizard-server" {
+  project_id = vercel_project.theme-wizard-server.id
+  domain     = "theme-wizard-server.nl-design-system-community.nl"
+}
+
+import {
+  to = vercel_project_domain.theme-wizard-server
+  id = "prj_APeeEd1j3BGODnrqQtjIZ1WISlK7/theme-wizard-server.nl-design-system-community.nl"
 }
 
 resource "vercel_project" "clippy-storybook" {

--- a/theme-wizard.tf
+++ b/theme-wizard.tf
@@ -189,7 +189,6 @@ resource "github_repository_environment_deployment_policy" "theme-wizard-publish
 
 resource "vercel_project" "theme-wizard" {
   name                    = "theme-wizard"
-  ignore_command          = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
   node_version            = "24.x"
   root_directory          = "packages/theme-wizard-website/"
   enable_preview_feedback = false
@@ -207,7 +206,6 @@ resource "vercel_project" "theme-wizard" {
 
 resource "vercel_project" "theme-wizard-server" {
   name                                              = "theme-wizard-server"
-  ignore_command                                    = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
   node_version                                      = "24.x"
   automatically_expose_system_environment_variables = true
   root_directory                                    = "packages/theme-wizard-server/"
@@ -226,12 +224,9 @@ resource "vercel_project" "theme-wizard-server" {
 
 resource "vercel_project" "clippy-storybook" {
   name                    = "clippy-storybook"
-  ignore_command          = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
   node_version            = "24.x"
   root_directory          = "packages/clippy-storybook/"
   enable_preview_feedback = false
-
-
 
   git_repository = {
     type = "github"

--- a/tilburg.tf
+++ b/tilburg.tf
@@ -191,9 +191,8 @@ resource "github_repository_environment_deployment_policy" "tilburg-publish-main
 
 resource "vercel_project" "tilburg" {
   name                    = github_repository.tilburg.name
-  output_directory        = "packages/storybook/dist/"
-  ignore_command          = "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
   node_version            = "24.x"
+  root_directory          = "packages/storybook/"
   enable_preview_feedback = false
 
   git_repository = {


### PR DESCRIPTION
1. Imports vercel projects that were manually created
2. Removes configuration that should be in vercel.json. vercel.json will now live in the package folder (so preferably not in the root) to accomodate for having multiple vercel deployments per repo. So this is why rootDirectory is added for every project.
3. Skipping dependabot/gh-pages deployments is done through vercel.json so this is also removed from terraform.

This PR should be merged somewhat simultaneously with:
- https://github.com/nl-design-system/lux/pull/659
- https://github.com/nl-design-system/mijn-services/pull/539
- https://github.com/nl-design-system/rijkshuisstijl-community/pull/2817
- https://github.com/nl-design-system/rotterdam/pull/586
- https://github.com/nl-design-system/rvo/pull/1696
- https://github.com/nl-design-system/tilburg/pull/346
- https://github.com/nl-design-system/utrecht/pull/3208
- https://github.com/nl-design-system/editor/pull/570